### PR TITLE
Changed i18n "ID de impuesto" to "RNC" in module point of sale

### DIFF
--- a/ncf_pos/i18n/es_DO.po
+++ b/ncf_pos/i18n/es_DO.po
@@ -1,0 +1,7 @@
+#. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/xml/pos.xml:384
+#: code:addons/point_of_sale/static/src/xml/pos.xml:452
+#, python-format
+msgid "Tax ID"
+msgstr "RNC"


### PR DESCRIPTION
The text "Tax ID" was changed to "RNC"