### PR TITLE
Turning readonly to vat and fiscal type (Ref: Resolve #66)

### DIFF
--- a/ncf_pos/static/src/js/screens.js
+++ b/ncf_pos/static/src/js/screens.js
@@ -221,61 +221,42 @@ odoo.define('ncf_pos.screens', function (require) {
             function has_client_fiscal_type(client, fiscal_types) {
                 return _.contains(fiscal_types, client.sale_fiscal_type) && !has_client_vat(client);
             }
-            
-            if(order.get_total_with_tax() <= 0) {
-                this.gui.show_popup('error', {
-                    'title': 'Error: Cantidad de articulos a pagar',
-                    'body': 'La orden esta vacia, no existen articulos a pagar.',
-                    'cancel': function() {
-                        this.gui.show_screen('products');
-                    }
-                });
 
-                return false;
-            } else if (this.pos.config.iface_invoicing && !client) {
-                this.gui.show_popup('error', {
-                    'title': 'Error: Factura sin Cliente',
-                    'body': 'Debe seleccionar un cliente para poder realizar el pago, o utilizar el cliente por defecto; de no tener un cliente por defecto, pida ayuda a su encargado para que lo establezca.',
-                    'cancel': function () {
-                        this.gui.show_screen('products');
-                    }
-                });
+            if (!client){
+                if (this.pos.config.iface_invoicing) {
+                    this.gui.show_popup('error', {
+                        'title': 'Error: Factura sin Cliente',
+                        'body': 'Debe seleccionar un cliente para poder realizar el pago, o utilizar el cliente por defecto; de no tener un cliente por defecto, pida ayuda a su encargado para que lo establezca.',
+                        'cancel': function () {
+                            this.gui.show_screen('products');
+                        }
+                    });
 
-                return false;
-            } else if (order.get_total_without_tax() >= 50000 && !has_client_vat(client)) {
-                this.gui.show_popup('error', {
-                    'title': 'Error: Factura sin Cedula de Cliente',
-                    'body': 'El cliente debe tener una cedula si el total de la factura es igual o mayor a RD$50,000 o mas',
-                    'cancel': function () {
-                        this.gui.show_screen('products');
-                    }
-                });
-
-                return false;
-            } else if (has_client_fiscal_type(client, ["fiscal", "gov", "special"])) {
-                this.gui.show_popup('error', {
-                    'title': 'Error: Para el tipo de comprobante',
-                    'body': 'No puede crear una factura con crédito fiscal si el cliente no tiene RNC o Cédula. Puede pedir ayuda para que el cliente sea registrado correctamente si este desea comprobante fiscal',
-                    'cancel': function () {
-                        this.gui.show_screen('products');
-                    }
-                });
-                return false;
+                    return false;
+                }
             } else {
-                order.orderlines.find(function(line) {
-                    if (line.get_price_with_tax() < 0) {
-                        this.gui.show_popup('error', {
-                            'title': 'Error: Precio de producto',
-                            'body': 'Ningun producto puede tener precio menor a RD$0',
-                            'cancel': function() {
-                                this.gui.show_screen('products');
-                            }
-                        });
+                if (has_client_fiscal_type(client, ["fiscal", "gov", "special"]) && !has_client_vat(client)) {
+                    this.gui.show_popup('error', {
+                        'title': 'Error: Para el tipo de comprobante',
+                        'body': 'No puede crear una factura con crédito fiscal si el cliente no tiene RNC o Cédula. Puede pedir ayuda para que el cliente sea registrado correctamente si este desea comprobante fiscal',
+                        'cancel': function () {
+                            this.gui.show_screen('products');
+                        }
+                    });
+                    return false;
+                }
 
-                        return true;
-                    }
-                });
-                
+                if (this.pos.config.iface_invoicing && order.get_total_without_tax() >= 50000 && !has_client_vat(client)) {
+                    this.gui.show_popup('error', {
+                        'title': 'Error: Factura sin Cedula de Cliente',
+                        'body': 'El cliente debe tener una cedula si el total de la factura es igual o mayor a RD$50,000 o mas',
+                        'cancel': function () {
+                            this.gui.show_screen('products');
+                        }
+                    });
+
+                    return false;
+                }
             }
 
             this._super();
@@ -322,30 +303,6 @@ odoo.define('ncf_pos.screens', function (require) {
                             self.gui.show_screen('products');
                         }
                     });
-                } else if (self.pos.config.iface_invoicing && !client) {
-                    self.gui.show_popup('error', {
-                        'title': 'Error: Factura sin Cliente',
-                        'body': 'Debe seleccionar un cliente para poder realizar el pago, o utilizar el cliente por defecto; de no tener un cliente por defecto, pida ayuda a su encargado para que lo establezca.',
-                        'cancel': function () {
-                            self.gui.show_screen('products');
-                        }
-                    });
-                } else if (order.get_total_without_tax() >= 50000 && !has_client_vat(client)) {
-                    self.gui.show_popup('error', {
-                        'title': 'Error: Factura sin Cedula de Cliente',
-                        'body': 'El cliente debe tener una cedula si el total de la factura es igual o mayor a RD$50,000 o mas',
-                        'cancel': function () {
-                            self.gui.show_screen('products');
-                        }
-                    });
-                } else if (has_client_fiscal_type(client, ["fiscal", "gov", "special"])) {
-                    self.gui.show_popup('error', {
-                        'title': 'Error: Para el tipo de comprobante',
-                        'body': 'No puede crear una factura con crédito fiscal si el cliente no tiene RNC o Cédula. Puede pedir ayuda para que el cliente sea registrado correctamente si este desea comprobante fiscal',
-                        'cancel': function () {
-                            self.gui.show_screen('products');
-                        }
-                    });
                 } else {
                     order.orderlines.find(function(line) {
                         if (line.get_price_with_tax() < 0) {
@@ -360,6 +317,43 @@ odoo.define('ncf_pos.screens', function (require) {
                             return true;
                         }
                     });
+                }
+
+                if (!client){
+                    if (this.pos.config.iface_invoicing) {
+                        this.gui.show_popup('error', {
+                            'title': 'Error: Factura sin Cliente',
+                            'body': 'Debe seleccionar un cliente para poder realizar el pago, o utilizar el cliente por defecto; de no tener un cliente por defecto, pida ayuda a su encargado para que lo establezca.',
+                            'cancel': function () {
+                                this.gui.show_screen('products');
+                            }
+                        });
+
+                        return false;
+                    }
+                } else {
+                    if (has_client_fiscal_type(client, ["fiscal", "gov", "special"]) && !has_client_vat(client)) {
+                        this.gui.show_popup('error', {
+                            'title': 'Error: Para el tipo de comprobante',
+                            'body': 'No puede crear una factura con crédito fiscal si el cliente no tiene RNC o Cédula. Puede pedir ayuda para que el cliente sea registrado correctamente si este desea comprobante fiscal',
+                            'cancel': function () {
+                                this.gui.show_screen('products');
+                            }
+                        });
+                        return false;
+                    }
+
+                    if (this.pos.config.iface_invoicing && order.get_total_without_tax() >= 50000 && !has_client_vat(client)) {
+                        this.gui.show_popup('error', {
+                            'title': 'Error: Factura sin Cedula de Cliente',
+                            'body': 'El cliente debe tener una cedula si el total de la factura es igual o mayor a RD$50,000 o mas',
+                            'cancel': function () {
+                                this.gui.show_screen('products');
+                            }
+                        });
+
+                        return false;
+                    }
                 }
 
                 // Here end the method extension

--- a/ncf_pos/static/src/js/screens.js
+++ b/ncf_pos/static/src/js/screens.js
@@ -276,7 +276,6 @@ odoo.define('ncf_pos.screens', function (require) {
                     }
                 });
                 
-                return false;
             }
 
             this._super();

--- a/ncf_pos/static/src/xml/pos.xml
+++ b/ncf_pos/static/src/xml/pos.xml
@@ -3,13 +3,13 @@
 
     <t t-extend="ClientDetailsEdit">
         <t t-jquery=".client-name" t-operation="replace">
-            <t t-if="partner.name">
+            <t t-if="!partner.name or partner.sale_fiscal_type === 'final'">
+                <input class='detail client-name' name='name' t-att-value='partner.name' placeholder='Name'/>
+            </t>
+            <t t-else="">
                 <span class='detail client-name' name='name'>
                     <t t-esc="partner.name"/>
                 </span>
-            </t>
-            <t t-else="">
-                <input class='detail client-name' name='name' t-att-value='partner.name' placeholder='Name'/>
             </t>
         </t>
         <t t-jquery=".client-details-left" t-operation="append">

--- a/ncf_pos/static/src/xml/pos.xml
+++ b/ncf_pos/static/src/xml/pos.xml
@@ -6,17 +6,16 @@
 
             <div class='client-detail'>
                 <span class='label'>NCF</span>
-                <select class='detail client-fiscal-type needsclick' name='sale_fiscal_type'>
-                    <option value=''>None</option>
+                <span>
                     <t t-foreach='widget.pos.sale_fiscal_type_selection' t-as='row'>
-                        <option t-att-value='row[0]'
-                                t-att-selected="partner.sale_fiscal_type ? ((row[0] === partner.sale_fiscal_type) ? true : undefined) : undefined">
-                            <t t-esc='row[1]'/>
-                        </option>
+                        <t t-if="partner.sale_fiscal_type ? ((row[0] === partner.sale_fiscal_type) ? true : undefined) : undefined" t-esc="row[1]"/>
                     </t>
-                </select>
+                </span>
             </div>
 
+        </t>
+        <t t-jquery=".detail.vat" t-operation="replace">
+            <span class='detail vat' name='vat' t-esc='partner.vat || "N/A"'></span>
         </t>
     </t>
 

--- a/ncf_pos/static/src/xml/pos.xml
+++ b/ncf_pos/static/src/xml/pos.xml
@@ -2,20 +2,48 @@
 <templates id="template">
 
     <t t-extend="ClientDetailsEdit">
+        <t t-jquery=".client-name" t-operation="replace">
+            <t t-if="partner.name">
+                <span class='detail client-name' name='name'>
+                    <t t-esc="partner.name"/>
+                </span>
+            </t>
+            <t t-else="">
+                <input class='detail client-name' name='name' t-att-value='partner.name' placeholder='Name'/>
+            </t>
+        </t>
         <t t-jquery=".client-details-left" t-operation="append">
-
             <div class='client-detail'>
                 <span class='label'>NCF</span>
-                <span>
-                    <t t-foreach='widget.pos.sale_fiscal_type_selection' t-as='row'>
-                        <t t-if="partner.sale_fiscal_type ? ((row[0] === partner.sale_fiscal_type) ? true : undefined) : undefined" t-esc="row[1]"/>
-                    </t>
-                </span>
+                <t t-if="partner.name">
+                    <span>
+                        <t t-foreach='widget.pos.sale_fiscal_type_selection' t-as='row'>
+                            <t t-if="partner.sale_fiscal_type ? ((row[0] === partner.sale_fiscal_type) ? true : undefined) : undefined" t-esc="row[1]"/>
+                        </t>
+                    </span>
+                </t>
+                <t t-else="">
+                    <select class='detail client-fiscal-type needsclick' name='sale_fiscal_type'>
+                        <option value=''>None</option>
+                        <t t-foreach='widget.pos.sale_fiscal_type_selection' t-as='row'>
+                            <option t-att-value='row[0]'
+                                    t-att-selected="partner.sale_fiscal_type ? ((row[0] === partner.sale_fiscal_type) ? true : undefined) : undefined">
+                                <t t-esc='row[1]'/>
+                            </option>
+                        </t>
+                    </select>
+                </t>
             </div>
-
         </t>
         <t t-jquery=".detail.vat" t-operation="replace">
-            <span class='detail vat' name='vat' t-esc='partner.vat || "N/A"'></span>
+            <t t-if="partner.name">
+                <span class="detail vat" name="vat">
+                    <t t-esc="partner.vat || 'N/A'"/>
+                </span>
+            </t>
+            <t t-else="">
+                <input class='detail vat' name='vat' t-att-value='partner.vat || ""'/>
+            </t>
         </t>
     </t>
 


### PR DESCRIPTION
En este PR se evita que desde la pantalla de listado de clientes se pueda cambiar tipo fiscal y la cedula o RNC.

Se determinó que estos campos deben ser readonly desde la creacion de un contacto en adelante para evitar errores de asignacion de rnc a otras personas o entidades.