### PR TITLE
[FIX] Just require NCF configuration for invoices with NCF journals

### DIFF
--- a/ncf_manager/models/account_move.py
+++ b/ncf_manager/models/account_move.py
@@ -20,7 +20,7 @@
 # along with NCF Manager.  If not, see <http://www.gnu.org/licenses/>.
 # ######################################################################
 from odoo import models, api, _
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import UserError
 
 
 class AccountMove(models.Model):
@@ -29,13 +29,15 @@ class AccountMove(models.Model):
     @api.multi
     def post(self):
         invoice = self._context.get('invoice', False)
-        if invoice and invoice.type == "out_invoice":
-            if not invoice.is_nd:
-                return super(AccountMove, self.with_context(sale_fiscal_type=invoice.sale_fiscal_type)).post()
-            else:
-                return super(AccountMove, self.with_context(sale_fiscal_type="debit_note")).post()
-        elif invoice and invoice.type == "out_refund":
-            return super(AccountMove, self.with_context(sale_fiscal_type="credit_note")).post()
+        if invoice and invoice.journal_id.ncf_control:
+            if not invoice.journal_id.ncf_ready:
+                raise UserError(_("Debe configurar los NCF para este diario."))
+            if invoice.type == "out_invoice":
+                if invoice.is_nd:
+                    return super(AccountMove, self.with_context(sale_fiscal_type="debit_note")).post()
+                else:
+                    return super(AccountMove, self.with_context(sale_fiscal_type=invoice.sale_fiscal_type)).post()
+            elif invoice.type == "out_refund":
+                return super(AccountMove, self.with_context(sale_fiscal_type="credit_note")).post()
         else:
             return super(AccountMove, self).post()
-


### PR DESCRIPTION
El parámetro `sale_fiscal_type` solo debe enviarse a través de la factura si el diario de esa factura tiene el ncf_control activado, de lo contrario se estaría requiriendo que los comprobantes estén configurados cuando no son necesarios.