### PR TITLE
Allowing CORS on dgii-related route

### DIFF
--- a/ncf_manager/controllers/controllers.py
+++ b/ncf_manager/controllers/controllers.py
@@ -14,7 +14,7 @@ except(ImportError, IOError) as err:
 
 
 class Odoojs(http.Controller):
-    @http.route('/dgii_ws', auth='public')
+    @http.route('/dgii_ws', auth='public', cors="*")
     def index(self, **kwargs):
         """
         Look for clients in the web service of the DGII


### PR DESCRIPTION
Este PR agrega la capacidad de CORS a la ruta del webservice de la DGII.  

@gustavovalverde puedes probarlo. Ya funciona nitido fuera del POS. En el POS funciona la busqueda, pero si solo colocas el rnc/cedula y le das a guardar, se guardara el rnc/cedula. No funciona igual que el backend, pero es porque no esta programado asi aun.

@eneldoserrata hay que anotar eso por ahi, por si acaso da de nuevo.

Close #168