### PR TITLE
[FIX] close #220

### DIFF
--- a/ncf_manager/views/account_invoice_view.xml
+++ b/ncf_manager/views/account_invoice_view.xml
@@ -28,19 +28,28 @@
                 <field name="sale_fiscal_type" attrs="{
                        'invisible':[('type','=','out_refund')],
                        'required': [('ncf_control','=',True),('type','=','out_invoice')],
-                       'readonly': [('state','!=','draft')]}"/>
+                       'readonly': ['|',('state','!=','draft'),('move_name','!=',False),('move_name','!=',False)]}"/>
                 <field name="income_type" attrs="{
                        'invisible':[('ncf_control','!=',True)],
                        'required': [('ncf_control','=',True),('type','=','out_invoice')],
                        'readonly': [('state','!=','draft')]}"/>
             </field>
 
-            <field name="number" position="before">
-                <h2 attrs="{'invisible': [('state','!=','cancel')]}">
-                    FACTURA CANCELADA <br/>
-                <field name="anulation_type" readonly="1"/>
-                </h2>
-            </field>
+            <field name="move_name" position="replace"/>
+            <xpath expr="//h1" position="after">
+                <h4 attrs="{'invisible': ['|', ('state', '=', 'draft'), ('move_name', '=', False)]}">
+                    Válido hasta:
+                    <field name="ncf_expiration_date" readonly="1"/>
+                </h4>
+                <h4 states="draft,cancel">
+                    <field name="move_name" readonly="1" attrs="{'invisible':[('move_name','=',False)]}"/>
+                </h4>
+                <h4 attrs="{'invisible':[('state','!=','cancel')]}">
+                    Factura cancelada por:
+                    <br/>
+                    <field name="anulation_type" readonly="1"/>
+                </h4>
+            </xpath>
 
             <xpath expr="//page[@name='other_info']//field[@name='origin']" position="replace"/>
 
@@ -65,13 +74,6 @@
                        ('income_type', '=', income_type)]"/>
             </xpath>
 
-            <xpath expr="//field[@name='number']" position="after">
-                <h3 attrs="{'invisible': ['|', ('state', '=', 'draft'), ('sale_fiscal_type', '=', False)]}">
-                    Válido hasta:
-                    <field name="ncf_expiration_date" readonly="1"/>
-                </h3>
-            </xpath>
-
         </field>
     </record>
 
@@ -85,7 +87,7 @@
             <xpath expr="//button[@name='%(account.action_account_invoice_refund)d']" position="attributes">
                 <attribute name="string">Aplicar NC o ND</attribute>
             </xpath>
-            
+
             <field name="origin" position="replace"/>
 
             <field name="number" position="after">

--- a/ncf_manager/views/account_invoice_view.xml
+++ b/ncf_manager/views/account_invoice_view.xml
@@ -28,7 +28,7 @@
                 <field name="sale_fiscal_type" attrs="{
                        'invisible':['|',('type','=','out_refund'),('ncf_control','=',False)],
                        'required': [('ncf_control','=',True),('type','=','out_invoice')],
-                       'readonly': ['|',('state','!=','draft'),('move_name','!=',False),('move_name','!=',False)]}"/>
+                       'readonly': ['|',('state','!=','draft'),('move_name','!=',False)]}"/>
                 <field name="income_type" attrs="{
                        'invisible':[('ncf_control','!=',True)],
                        'required': [('ncf_control','=',True),('type','=','out_invoice')],

--- a/ncf_manager/views/account_invoice_view.xml
+++ b/ncf_manager/views/account_invoice_view.xml
@@ -37,7 +37,7 @@
 
             <field name="move_name" position="replace"/>
             <xpath expr="//h1" position="after">
-                <h4 attrs="{'invisible': ['|', ('state', '=', 'draft'), ('move_name', '=', False)]}">
+                <h4 attrs="{'invisible': ['|', ('state', '=', 'draft'), ('move_name', '=', False), ('ncf_control','=',False)]}">
                     Válido hasta:
                     <field name="ncf_expiration_date" readonly="1"/>
                 </h4>

--- a/ncf_manager/views/account_invoice_view.xml
+++ b/ncf_manager/views/account_invoice_view.xml
@@ -45,7 +45,7 @@
                     <field name="move_name" readonly="1" attrs="{'invisible':[('move_name','=',False)]}"/>
                 </h4>
                 <h4 attrs="{'invisible':[('state','!=','cancel')]}">
-                    Factura cancelada por:
+                    Razón de Cancelación:
                     <br/>
                     <field name="anulation_type" readonly="1"/>
                 </h4>


### PR DESCRIPTION
clone #220 

1. sale_fiscal_type readonly in draft if move_name already have assigned sequence
2. shows the sequence assigned in the draft and cancel states