### PR TITLE
Método para validar la no duplicidad de NCF en Facturas de clientes

### DIFF
--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -169,6 +169,7 @@ class AccountInvoice(models.Model):
     def _check_unique_invoice(self):
         """ Validates out_invoice unique number by company, partner and journal """
         for invoice in self:
+            result = []
             if invoice.number:
                 query = """
                 SELECT id

--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -164,6 +164,30 @@ class AccountInvoice(models.Model):
         ]
         self._add_sql_constraints()
 
+    @api.multi
+    @api.constrains('number', 'company_id', 'partner_id', 'journal_id', 'type')
+    def _check_unique_invoice(self):
+        """ Validates out_invoice unique number by company, partner and journal """
+        for invoice in self:
+            if invoice.number:
+                query = """
+                SELECT id
+                FROM account_invoice
+                WHERE number = '{number}'
+                AND company_id = {company}
+                AND partner_id = {partner}
+                AND journal_id = {journal}
+                AND type = 'out_invoice'
+                """.format(number=invoice.number,
+                           company=invoice.company_id.id,
+                           partner=invoice.partner_id.id,
+                           journal=invoice.journal_id.id)
+
+                self._cr.execute(query)
+                result = self._cr.fetchall()
+                if len(result) >= 1:
+                    raise ValidationError(_('Invoice Number must be unique per Company!'))
+
     def purchase_ncf_validate(self):
         if not self.journal_id.purchase_type == 'normal':
             return


### PR DESCRIPTION
He creado un método que consulta la ocurrencia del número, compañía, cliente, diario y tipo de factura, solo cuando la factura sea tipo 'out_invoice'.

De esta forma, el constraint que ya existe y que aplica para 'in_invoice', siga funcionando igual.

Ver link:
https://github.com/odoo-dominicana/l10n-dominicana/blob/ec56027b323c8184f46d69e61c446290749ebb2f/ncf_manager/models/account_invoice.py#L157

Close #227

