### PR TITLE
[FIX] ncf_manager: InvalidFormat error on create

### DIFF
--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -322,10 +322,11 @@ class AccountInvoice(models.Model):
     @api.model
     def create(self, vals):
         if vals.get("sale_fiscal_type", None) == "fiscal":
-            partner = vals.get("partner_id", None)
 
-            if partner:
-                if len(self.env["res.partner"].browse(partner).vat) not in [9, 11] or not rnc.check_dgii(str(partner)):
+            partner_id = self.env["res.partner"].browse(vals['partner_id'])
+
+            if partner_id:
+                if len(partner_id.vat) not in [9, 11] or not rnc.check_dgii(str(partner_id.vat)):
                     raise ValidationError(_(
                         "El RNC del cliente NO pasó la validación en DGII\n\n"
                         "No es posible crear una factura con Crédito Fiscal si el RNC del cliente es inválido."


### PR DESCRIPTION
Considering that partner_id is a table level required field
I call it using this format: vals['partner_id'] and construct
the object at the same time.

Also fixed that check_dgii() method was receiving partner id,
instead of partner vat.