### PR TITLE
[FIX] ncf_invoice_template: show E when exempt itbis

### DIFF
--- a/ncf_invoice_template/report/report_invoice.xml
+++ b/ncf_invoice_template/report/report_invoice.xml
@@ -160,6 +160,7 @@
                 </thead>
                 <tbody class="invoice_tbody">
                     <tr t-foreach="o.invoice_line_ids" t-as="l">
+                        <t t-set="exempt_itbis" t-value="any([t for t in l.invoice_line_tax_ids if t.amount == 0.0])"/>
                         <td>
                             <span t-field="l.name"/>
                         </td>


### PR DESCRIPTION
Added missing code line which evaluate if invoice line is ITBIS exempt.