### PR TITLE
[FIX] ncf_manager: Fix Odoo's sequence with date_range

### DIFF
--- a/ncf_manager/models/ir_sequence.py
+++ b/ncf_manager/models/ir_sequence.py
@@ -64,6 +64,10 @@ class IrSequence(models.Model):
                 seq_date = self._create_date_range_seq(dt)
             return seq_date.with_context(ir_sequence_date_range=seq_date.date_from)._next()
         else:
+            # date mode
+            if self._context.get('ir_sequence_date'):
+                dt = self._context.get('ir_sequence_date')
+
             seq_date = self.env['ir.sequence.date_range'].search(
                 [('sale_fiscal_type', '=', False), ('sequence_id', '=', self.id), ('date_from', '<=', dt),
                  ('date_to', '>=', dt)], limit=1)


### PR DESCRIPTION
If an invoice from a date older than the current year was tried to be used, it would commonly fail if there wasn't a date sequence  with the invoice date.

This was caused because the date context was not passed to Odoo's sequence, but just to the NCF sequence.