### PR TITLE
[FIX] ncf_manager: Use move_name for cancelled invoices

### DIFF
--- a/ncf_invoice_template/report/report_invoice.xml
+++ b/ncf_invoice_template/report/report_invoice.xml
@@ -133,7 +133,7 @@
                 </div>
                 <div class="col-auto mw-100 mb-2" t-if="o.reference" name="reference">
                     <strong>Factura No.:</strong>
-                    <p class="m-0" t-field="o.number"/>
+                    <p class="m-0" t-field="o.move_name"/>
                 </div>
             </div>
         </xpath>


### PR DESCRIPTION
Number is removed in cancelled invoices, but move_name is not.