### PR TITLE
[ADD] ncf_manager: added new purchase NCF: Pagos al Exterior

### DIFF
--- a/ncf_manager/models/account.py
+++ b/ncf_manager/models/account.py
@@ -28,13 +28,15 @@ class AccountJournal(models.Model):
         self.ensure_one()
         self.ncf_ready = len(self.date_range_ids) > 1
 
-    purchase_type = fields.Selection(
-        [("normal", "Compras Fiscales"),
-         ("minor", "Gastos Menores"),
-         ("informal", "Proveedores Informales"),
-         ("exterior", "Remesas al Exterior"),
-         ("import", "Importaciones"),
-         ("others", "Otros (sin NCF)")],
+    purchase_type = fields.Selection([
+        ("normal", "Compras Fiscales"),
+        ("minor", "Gastos Menores"),
+        ("informal", "Proveedores Informales"),
+        ("exterior", "Remesas al Exterior"),
+        ("import", "Importaciones"),
+        ("ext_payment", "Pagos al Exterior"),
+        ("others", "Otros (sin NCF)"),
+    ],
         string="Tipo de Compra",
         default="others")
 

--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -377,9 +377,10 @@ class AccountInvoice(models.Model):
         """ After all invoice validation routine, consume a NCF sequence and
             write it into reference field.
          """
-        if not self.reference and (
-                self.journal_id.ncf_control or
-                self.journal_id.purchase_type in ['minor', 'informal', 'ext_payment']):
+        if not self.reference and (self.journal_id.ncf_control or
+                                   self.journal_id.purchase_type in [
+                                       'minor', 'informal', 'ext_payment'
+                                   ]):
             sequence_id = self.journal_id.sequence_id
             if self.type == 'out_invoice':
                 if self.is_nd:

--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -338,7 +338,7 @@ class AccountInvoice(models.Model):
          """
         if not self.reference and (
                 self.journal_id.ncf_control or
-                self.journal_id.purchase_type in ['minor', 'informal']):
+                self.journal_id.purchase_type in ['minor', 'informal', 'ext_payment']):
             sequence_id = self.journal_id.sequence_id
             if self.type == 'out_invoice':
                 if self.is_nd:

--- a/ncf_manager/models/ir_sequence.py
+++ b/ncf_manager/models/ir_sequence.py
@@ -35,7 +35,8 @@ class IrSequence(models.Model):
         "debit_note": "03",
         "credit_note": "04",
         "minor": "13",
-        "informal": "11"
+        "informal": "11",
+        "ext_payment": "17",
     }
 
     ncf_control = fields.Boolean("Control de NCF", default=False)
@@ -101,7 +102,9 @@ class IrSequenceDateRange(models.Model):
                 [("credit_note", u"Nota de Crédito"),
                  ("debit_note", u"Nota de Débito"),
                  ("minor", "Gastos Menores"),
-                 ("informal", "Proveedores Informales")])
+                 ("informal", "Proveedores Informales"),
+                 ("ext_payment", "Pagos al Exterior"),
+                 ])
 
     sale_fiscal_type = fields.Selection("get_sale_fiscal_type_from_partner",
                                         string="NCF para")


### PR DESCRIPTION
**Artículo 9**. Del Comprobante para Pagos al Exterior. Se entenderá como comprobante para pagos al exterior, aquellos emitidos por concepto de pago de rentas gravadas de fuente dominicana a personas físicas o jurídicas no residentes fiscales obligadas a realizar la retención total del Impuesto sobre la Renta, de conformidad a los artículos 297 y 305 del Código Tributario.