### PR TITLE
[FIX] ncf_manager: Do not change invoice reference from the purchase

### DIFF
--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -277,14 +277,6 @@ class AccountInvoice(models.Model):
     @api.onchange("reference", "origin_out")
     def onchange_ncf(self):
         if self.journal_id.purchase_type in ('normal', 'informal', 'minor'):
-            NCF = self.reference if self.reference else None
-            purchase_id = self.env.context.get('default_purchase_id', False)
-            if purchase_id and NCF and NCF[0:3] not in ['B01', 'B04']:
-                self.update({
-                    'name': self.env.context.get('default_origin'),
-                    'purchase_id': self.env.context.get('default_purchase_id'),
-                    'reference': '',
-                })
             self.validate_fiscal_purchase()
 
         if self.origin_out and (self.type == 'out_refund' or

--- a/ncf_purchase/models/account_invoice.py
+++ b/ncf_purchase/models/account_invoice.py
@@ -37,14 +37,33 @@ class AccountInvoice(models.Model):
             if supplier.purchase_journal_id:
                 self.journal_id = supplier.purchase_journal_id
 
-    @api.onchange('invoice_line_ids')
-    def _onchange_origin(self):
-        """This method is being inherited as Odoo uses the purchase reference
+    @api.onchange('purchase_id')
+    def purchase_order_change(self):
+        """This method is being overwritten as Odoo uses the purchase reference
             and puts it into the invoice reference (our NCF), we change this
             behaviour to use the invoice name (description)"""
-        purchase_ids = self.invoice_line_ids.mapped('purchase_id')
-        if purchase_ids:
-            self.origin = ', '.join(purchase_ids.mapped('name'))
-            self.name = ', '.join(
-                purchase_ids.filtered('partner_ref').mapped(
-                    'partner_ref')) or self.reference
+        if not self.purchase_id:
+            return {}
+        if not self.partner_id:
+            self.partner_id = self.purchase_id.partner_id.id
+
+        vendor_ref = self.purchase_id.partner_ref
+        if vendor_ref:
+            # Here, l10n_dominicana changes self.reference to self.name
+            self.name = ", ".join([self.name, vendor_ref]) if (
+                self.name and vendor_ref not in self.name) else vendor_ref
+
+        new_lines = self.env['account.invoice.line']
+        for line in self.purchase_id.order_line - self.invoice_line_ids.mapped(
+                'purchase_line_id'):
+            data = self._prepare_invoice_line_from_po_line(line)
+            new_line = new_lines.new(data)
+            new_line._set_additional_fields(self)
+            new_lines += new_line
+
+        self.invoice_line_ids += new_lines
+        self.payment_term_id = self.purchase_id.payment_term_id
+        self.env.context = dict(self.env.context,
+                                from_purchase_order_change=True)
+        self.purchase_id = False
+        return {}


### PR DESCRIPTION
The wrong method "_onchange_origin" was being replaced from upstream after march 11,
there's a commit removing the behavior that was affecting the localization
https://github.com/odoo/odoo/commit/1be873d40d7aa8b1959e3c5a1ec6a6ead2323b6a, but after
https://github.com/odoo/odoo/commit/a441e89c9fdeed9dfe92da10689c3cc981fead50 we had
the issue once again.

As Odoo is keeping this behavior on purchase_order_change and this can't be inherited
we have to completetely override this function.

This commit completely reverts 3f31b05 made by @yasmanycastillo