### PR TITLE
 [FIX] ncf_manager: Do not allow NCF modification on non-fiscal invoices

### DIFF
--- a/ncf_manager/views/account_invoice_view.xml
+++ b/ncf_manager/views/account_invoice_view.xml
@@ -96,9 +96,10 @@
             <xpath expr="//field[@name='reference']" position="attributes">
                 <attribute name="string">NCF</attribute>
                 <attribute name="attrs">{
-                'size': 19, 'invisible': [('purchase_type', 'not in', ['normal','minor','informal', 'exterior'])],
+                'invisible': [('purchase_type', 'not in', ['normal','minor','informal', 'exterior'])],
                 'required': [('purchase_type', '=', 'normal')],
-                'readonly': [('state', '!=', 'draft'), ('purchase_type', '=', 'normal')]}</attribute>
+                'readonly': ['|', '&',('state', '!=', 'draft'),('purchase_type', '=', 'normal'),('purchase_type', 'in', ['minor','informal', 'exterior'])]}
+                </attribute>
             </xpath>
 
             <xpath expr="//form[1]/sheet[1]/notebook[1]/page[@name='other_info']/group[1]/group[1]/field[@name='name']" position="replace"/>

--- a/ncf_manager/views/account_invoice_view.xml
+++ b/ncf_manager/views/account_invoice_view.xml
@@ -98,7 +98,7 @@
                 <attribute name="attrs">{
                 'invisible': [('purchase_type', 'not in', ['normal','minor','informal', 'exterior'])],
                 'required': [('purchase_type', '=', 'normal')],
-                'readonly': ['|', '&',('state', '!=', 'draft'),('purchase_type', '=', 'normal'),('purchase_type', 'in', ['minor','informal', 'exterior'])]}
+                'readonly': ['|', '&amp;',('state', '!=', 'draft'),('purchase_type', '=', 'normal'),('purchase_type', 'in', ['minor','informal', 'exterior'])]}
                 </attribute>
             </xpath>
 


### PR DESCRIPTION
This was allowing Minor and Informal invoices to be changed, which is a wrong behavior with critical consequences.