### PR TITLE
WIP New NCF structure

### DIFF
--- a/ncf_manager/__manifest__.py
+++ b/ncf_manager/__manifest__.py
@@ -43,6 +43,7 @@
     'data': [
         'data/ir_config_parameters.xml',
         'security/ir.model.access.csv',
+        'security/security.xml',
         'wizard/account_invoice_cancel_view.xml',
         'wizard/account_invoice_refund.xml',
         'views/account_invoice_view.xml',
@@ -51,6 +52,7 @@
         'views/assets_backend.xml',
         'views/ir_sequence_view.xml',
         'views/res_view.xml',
+        'views/ncf_manager_view.xml',
     ],
     'demo': ['demo/res_partner_demo.xml'],
     'qweb': ['static/src/xml/ncf_manager.xml']

--- a/ncf_manager/__manifest__.py
+++ b/ncf_manager/__manifest__.py
@@ -42,8 +42,8 @@
     'depends': ['account_invoicing', 'l10n_do', 'account_cancel'],
     'data': [
         'data/ir_config_parameters.xml',
-        'security/ir.model.access.csv',
         'security/security.xml',
+        'security/ir.model.access.csv',
         'wizard/account_invoice_cancel_view.xml',
         'wizard/account_invoice_refund.xml',
         'views/account_invoice_view.xml',

--- a/ncf_manager/i18n/es_DO.po
+++ b/ncf_manager/i18n/es_DO.po
@@ -1,3 +1,1168 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* ncf_manager
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-06-26 09:00+0000\n"
+"PO-Revision-Date: 2019-06-26 05:10-0400\n"
+"Last-Translator: <Yasmany Castillo>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"Language: es_DO\n"
+"X-Generator: Poedit 2.0.7\n"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "01 - Deterioro de Factura Pre-impresa"
+msgstr "01 - Deterioro de Factura Pre-impresa"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "01 - Gastos de Personal"
+msgstr "01 - Gastos de Personal"
+
+#. module: ncf_manager
+#: selection:account.invoice,income_type:0
+msgid "01 - Ingresos por Operaciones (No Financieros)"
+msgstr "01 - Ingresos por Operaciones (No Financieros)"
+
+#. module: ncf_manager
+#: selection:account.account,income_type:0
+msgid "01 - Ingresos por operaciones (No financieros)"
+msgstr "01 - Ingresos por operaciones (No financieros)"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "02 - Errores de Impresión (Factura Pre-impresa)"
+msgstr "02 - Errores de Impresión (Factura Pre-impresa)"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "02 - Gastos por Trabajo, Suministros y Servicios"
+msgstr "02 - Gastos por Trabajo, Suministros y Servicios"
+
+#. module: ncf_manager
+#: selection:account.account,income_type:0
+#: selection:account.invoice,income_type:0
+msgid "02 - Ingresos Financieros"
+msgstr "02 - Ingresos Financieros"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "03 - Arrendamientos"
+msgstr "03 - Arrendamientos"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "03 - Impresión Defectuosa"
+msgstr "03 - Impresión Defectuosa"
+
+#. module: ncf_manager
+#: selection:account.account,income_type:0
+#: selection:account.invoice,income_type:0
+msgid "03 - Ingresos Extraordinarios"
+msgstr "03 - Ingresos Extraordinarios"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "04 - Corrección de la Información"
+msgstr "04 - Corrección de la Información"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "04 - Gastos de Activos Fijos"
+msgstr "04 - Gastos de Activos Fijos"
+
+#. module: ncf_manager
+#: selection:account.account,income_type:0
+#: selection:account.invoice,income_type:0
+msgid "04 - Ingresos por Arrendamientos"
+msgstr "04 - Ingresos por Arrendamientos"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "05 - Cambio de Productos"
+msgstr "05 - Cambio de Productos"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "05 - Gastos de Representación"
+msgstr "05 - Gastos de Representación"
+
+#. module: ncf_manager
+#: selection:account.account,income_type:0
+#: selection:account.invoice,income_type:0
+msgid "05 - Ingresos por Venta de Activo Depreciable"
+msgstr "05 - Ingresos por Venta de Activo Depreciable"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "06 - Devolución de Productos"
+msgstr "06 - Devolución de Productos"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "06 - Otras Deducciones Admitidas"
+msgstr "06 - Otras Deducciones Admitidas"
+
+#. module: ncf_manager
+#: selection:account.account,income_type:0
+#: selection:account.invoice,income_type:0
+msgid "06 - Otros Ingresos"
+msgstr "06 - Otros Ingresos"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "07 - Gastos Financieros"
+msgstr "07 - Gastos Financieros"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "07 - Omisión de Productos"
+msgstr "07 - Omisión de Productos"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "08 - Errores en Secuencia de NCF"
+msgstr "08 - Errores en Secuencia de NCF"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "08 - Gastos Extraordinarios"
+msgstr "08 - Gastos Extraordinarios"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "09 - Compras y Gastos que forman parte del Costo de Venta"
+msgstr "09 - Compras y Gastos que forman parte del Costo de Venta"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "09 - Por Cese de Operaciones"
+msgstr "09 - Por Cese de Operaciones"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+#: selection:res.partner,expense_type:0
+msgid "10 - Adquisiciones de Activos"
+msgstr "10 - Adquisiciones de Activos"
+
+#. module: ncf_manager
+#: selection:account.invoice,anulation_type:0
+#: selection:account.invoice.cancel,anulation_type:0
+msgid "10 - Pérdida o Hurto de Talonarios"
+msgstr "10 - Pérdida o Hurto de Talonarios"
+
+#. module: ncf_manager
+#: selection:res.partner,expense_type:0
+msgid "11 - Gastos de Seguro"
+msgstr "11 - Gastos de Seguro"
+
+#. module: ncf_manager
+#: selection:account.account,expense_type:0
+#: selection:account.invoice,expense_type:0
+msgid "11 - Gastos de Seguros"
+msgstr "11 - Gastos de Seguros"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid ""
+"<strong>Esta opción no es válida para facturas pagadas.</strong>\n"
+"                                            Utilice esta opción si desea cancelar la factura que\n"
+"                                            Han emitido, La nota de crédito será creada, validada y reconciliada\n"
+"                                            Con la factura. No podrá modificar la nota de crédito."
+msgstr ""
+"<strong>Esta opción no es válida para facturas pagadas.</strong>\n"
+"                                            Utilice esta opción si desea cancelar la factura que\n"
+"                                            Han emitido, La nota de crédito será creada, validada y reconciliada\n"
+"                                            Con la factura. No podrá modificar la nota de crédito."
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid ""
+"<strong>Esta opción no es válida para facturas pagadas.</strong>\n"
+"                                            Utilice esta opción si desea cancelar una factura y crear una nueva.\n"
+"                                            La nota de crédito será creada, validada y reconciliada\n"
+"                                            Con la factura actual. Se creará una nueva factura en estado borrador\n"
+"                                            Para\n"
+"                                            que pueda editarla."
+msgstr ""
+"<strong>Esta opción no es válida para facturas pagadas.</strong>\n"
+"                                            Utilice esta opción si desea cancelar una factura y crear una nueva.\n"
+"                                            La nota de crédito será creada, validada y reconciliada\n"
+"                                            Con la factura actual. Se creará una nueva factura en estado borrador\n"
+"                                            Para\n"
+"                                            que pueda editarla."
+
+#. module: ncf_manager
+#: selection:account.journal,payment_form:0
+msgid "A Crédito"
+msgstr "A Crédito"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_account_account
+msgid "Account"
+msgstr "Cuenta"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_active
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+msgid "Active"
+msgstr "Activo"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_currency_form
+msgid "Actualizar desde el archivo del BC"
+msgstr "Actualizar desde el archivo del BC"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_origin_out
+msgid "Afecta a"
+msgstr "Afecta a"
+
+#. module: ncf_manager
+#: selection:account.tax,isr_retention_type:0
+msgid "Alquileres"
+msgstr "Alquileres"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_account_invoice_form
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_supplier_account_invoice_form
+msgid "Aplicar NC o ND"
+msgstr "Aplicar NC o ND"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+msgid "Archived"
+msgstr "Archivado"
+
+#. module: ncf_manager
+#: selection:account.journal,payment_form:0
+msgid "Bonos o Certificados de Regalo"
+msgstr "Bonos o Certificados de Regalo"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.account_invoice_cancel_view
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_form
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+#: selection:ncf.manager,state:0
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.account_invoice_cancel_view
+msgid "Cancel Invoices"
+msgstr "Cancelar facturas"
+
+#. module: ncf_manager
+#: model:ir.actions.act_window,name:ncf_manager.action_account_invoice_cancel
+#: model:ir.ui.view,arch_db:ncf_manager.account_invoice_cancel_view
+msgid "Cancel Selected Invoices"
+msgstr "Cancelar facturas seleccionadas"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_account_invoice_cancel
+msgid "Cancel the Selected Invoices"
+msgstr "Cancelar la factura seleccionada"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_account_invoice_form
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_supplier_account_invoice_form
+msgid "Cancelar Factura"
+msgstr "Cancelar Factura"
+
+#. module: ncf_manager
+#: selection:account.journal,payment_form:0
+msgid "Cheque / Transferencia / Depósito"
+msgstr "Cheque / Transferencia / Depósito"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_company_id
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+msgid "Company"
+msgstr "Compañía"
+
+#. module: ncf_manager
+#: selection:account.journal,purchase_type:0
+#: selection:ncf.manager,purchase_type:0
+msgid "Compras Fiscales"
+msgstr "Compras Fiscales"
+
+#. module: ncf_manager
+#: selection:account.journal,purchase_type:0
+#: selection:ncf.manager,purchase_type:0
+msgid "Comprobante de Compras"
+msgstr "Comprobante de Compras"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_form
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: ncf_manager
+#: selection:ncf.manager,state:0
+msgid "Confirmed"
+msgstr "Confirmado"
+
+#. module: ncf_manager
+#: selection:account.invoice,sale_fiscal_type:0
+#: selection:ncf.manager,sale_type:0 selection:res.partner,sale_fiscal_type:0
+msgid "Consumo"
+msgstr "Consumo"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_ncf_control
+#: model:ir.model.fields,field_description:ncf_manager.field_account_journal_ncf_control
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_ncf_control
+msgid "Control de NCF"
+msgstr "Control de NCF"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_res_currency_rate_converted
+msgid "Converted"
+msgstr "Convertir"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid "Crear"
+msgstr "Crear"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_form
+msgid "Create sequence"
+msgstr "Create sequence"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_cancel_create_uid
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_cancel_create_date
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_account_invoice_refund
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+#: selection:ncf.manager,sale_type:0
+msgid "Credit Note"
+msgstr "Nota de Crédito"
+
+#. module: ncf_manager
+#: selection:account.invoice,sale_fiscal_type:0
+#: selection:ncf.manager,sale_type:0 selection:res.partner,sale_fiscal_type:0
+msgid "Crédito Fiscal"
+msgstr "Crédito Fiscal"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_refund_account_id
+msgid "Cuenta contable"
+msgstr "Cuenta contable"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_res_currency
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_res_currency_rate
+msgid "Currency Rate"
+msgstr "Tasa"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/res.py:233
+#, python-format
+msgid "Debe especificar el tÃ©rmino de pago del contacto"
+msgstr "Debe especificar el tÃ©rmino de pago del contacto"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:361
+#, python-format
+msgid "Debe retener el 100% del ITBIS"
+msgstr "Debe retener el 100% del ITBIS"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid "Descripción de la opción"
+msgstr "Descripción de la opción"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_cancel_display_name
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_display_name
+msgid "Display Name"
+msgstr "Display Name"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+#: selection:ncf.manager,state:0
+msgid "Done"
+msgstr "Hecho"
+
+#. module: ncf_manager
+#: selection:ncf.manager,state:0
+msgid "Draft"
+msgstr "Borrador"
+
+#. module: ncf_manager
+#: selection:account.journal,payment_form:0
+msgid "Efectivo"
+msgstr "Efectivo"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:506
+#, python-format
+msgid ""
+"El RNC del cliente NO pasÃ³ la validaciÃ³n en DGII\n"
+"\n"
+"No es posible crear una factura con CrÃ©dito Fiscal si el RNC del cliente es invÃ¡lido.Verifique el RNC del cliente a fin de corregirlo y vuelva a guardar la factura"
+msgstr ""
+"El RNC del cliente NO pasÃ³ la validaciÃ³n en DGII\n"
+"\n"
+"No es posible crear una factura con CrÃ©dito Fiscal si el RNC del cliente es invÃ¡lido.Verifique el RNC del cliente a fin de corregirlo y vuelva a guardar la factura"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:380
+#, python-format
+msgid "El cliente [{}]{} no tiene RNC/CÃ©d, y es requeridopara este tipo de factura."
+msgstr "El cliente [{}]{} no tiene RNC/CÃ©d, y es requeridopara este tipo de factura."
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:373
+#, python-format
+msgid "El cliente [{}]{} no tiene Tipo de comprobante, y esrequerido para este tipo de factura."
+msgstr "El cliente [{}]{} no tiene Tipo de comprobante, y esrequerido para este tipo de factura."
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:76
+#, python-format
+msgid "Error. No sequence range for NCF para: {}"
+msgstr "Error. No sequence range for NCF para: {}"
+
+#. module: ncf_manager
+#: selection:account.invoice,sale_fiscal_type:0
+#: selection:ncf.manager,sale_type:0 selection:res.partner,sale_fiscal_type:0
+msgid "Exportaciones"
+msgstr "Exportaciones"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_res_partner_fiscal_info_required
+#: model:ir.model.fields,field_description:ncf_manager.field_res_users_fiscal_info_required
+msgid "Fiscal Info Required"
+msgstr "Información Fiscal requerida"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_ncf_number
+msgid "Fiscal Number"
+msgstr "NCF"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_fiscal_position_id
+msgid "Fiscal Position"
+msgstr "Posición Fiscal"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_journal_payment_form
+msgid "Forma de Pago"
+msgstr "Forma de Pago"
+
+#. module: ncf_manager
+#: selection:account.journal,purchase_type:0
+#: selection:ncf.manager,purchase_type:0
+msgid "Gastos Menores"
+msgstr "Gastos Menores"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+msgid "Group By..."
+msgstr "Agrupar por"
+
+#. module: ncf_manager
+#: selection:res.partner,sale_fiscal_type:0
+msgid "Gubernamental"
+msgstr "Gubernamental"
+
+#. module: ncf_manager
+#: selection:account.invoice,sale_fiscal_type:0
+#: selection:ncf.manager,sale_type:0
+msgid "Gubernamentales"
+msgstr "Gubernamentales"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_res_currency_bc_rate_xls
+msgid "Histórico en Excel de Tasas del Banco Central"
+msgstr "Histórico en Excel de Tasas del Banco Central"
+
+#. module: ncf_manager
+#: selection:account.tax,isr_retention_type:0
+msgid "Honorarios por Servicios"
+msgstr "Honorarios por Servicios"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_cancel_id
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_id
+msgid "ID"
+msgstr "ID"
+
+#. module: ncf_manager
+#: selection:account.tax,purchase_tax_type:0
+msgid "ISR Retenido"
+msgstr "ISR Retenido"
+
+#. module: ncf_manager
+#: selection:account.tax,purchase_tax_type:0
+msgid "ITBIS Pagado"
+msgstr "ITBIS Pagado"
+
+#. module: ncf_manager
+#: selection:account.tax,purchase_tax_type:0
+msgid "ITBIS Retenido"
+msgstr "ITBIS Retenido"
+
+#. module: ncf_manager
+#: selection:account.journal,purchase_type:0
+#: selection:ncf.manager,purchase_type:0
+msgid "Importaciones"
+msgstr "Importaciones"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid "Información de la nota de crédito"
+msgstr "Información de la nota de crédito"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid "Información de la nota de débito"
+msgstr "Información de la nota de débito"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid "Información del descuento"
+msgstr "Información del descuento"
+
+#. module: ncf_manager
+#: selection:account.tax,isr_retention_type:0
+msgid "Intereses Pagados a Personas Físicas"
+msgstr "Intereses Pagados a Personas Físicas"
+
+#. module: ncf_manager
+#: selection:account.tax,isr_retention_type:0
+msgid "Intereses Pagados a Personas Jurídicas"
+msgstr "Intereses Pagados a Personas Jurídicas"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_refund_invoice_type
+msgid "Invoice Type"
+msgstr "Tipo de Factura"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_invoice_ids
+msgid "Invoices"
+msgstr "Facturas"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_is_company_currency
+msgid "Is Company Currency"
+msgstr "Es la moneda de la compañía"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_is_nd
+msgid "Is Nd"
+msgstr "Es Nota de Crédito"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_account_journal
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_journal_id
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+msgid "Journal"
+msgstr "Diario"
+
+#. module: ncf_manager
+#: selection:account.tax,isr_retention_type:0
+msgid "Juegos Telefónicos"
+msgstr "Juegos Telefónicos"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:335
+#, python-format
+msgid "La venta de bienes a clientes extranjeros deben realizarse con comprobante tipo Exportaciones"
+msgstr "La venta de bienes a clientes extranjeros deben realizarse con comprobante tipo Exportaciones"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:340
+#, python-format
+msgid "La venta de servicios a clientes extranjeros deben realizarse con comprobante tipo Consumo"
+msgstr "La venta de servicios a clientes extranjeros deben realizarse con comprobante tipo Consumo"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/wizard/account_invoice_refund.py:148
+#, python-format
+msgid "Las Notas de CrÃ©dito deben ser tipo 04, este NCF no es de este tipo."
+msgstr "Las Notas de CrÃ©dito deben ser tipo 04, este NCF no es de este tipo."
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/wizard/account_invoice_refund.py:143
+#, python-format
+msgid "Las Notas de DÃ©bito deben ser tipo 03, este NCF no es de este tipo."
+msgstr "Las Notas de DÃ©bito deben ser tipo 03, este NCF no es de este tipo."
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_cancel___last_update
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager___last_update
+msgid "Last Modified on"
+msgstr "Last Modified on"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_cancel_write_uid
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_write_uid
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_cancel_write_date
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_write_date
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: ncf_manager
+#: model:res.groups,name:ncf_manager.group_ncf_manager
+msgid "Manage NCF structure"
+msgstr "Manejar Estructura NCF"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_refund_amount
+msgid "Monto"
+msgstr "Monto"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_refund_supplier_ncf
+#: model:ir.ui.menu,name:ncf_manager.ncf_manager_root_menu
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_account_invoice_form
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_account_invoice_tree
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_supplier_account_invoice_form
+msgid "NCF"
+msgstr "NCF"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:193
+#, python-format
+msgid ""
+"NCF *{}* NO corresponde con el tipo de documento\n"
+"\n"
+"No puede registrar Comprobantes Consumidor Final (02)"
+msgstr ""
+"NCF *{}* NO corresponde con el tipo de documento\n"
+"\n"
+"No puede registrar Comprobantes Consumidor Final (02)"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:238
+#, python-format
+msgid ""
+"NCF Duplicado en otra Factura\n"
+"\n"
+"El comprobante *{}* ya se encuentra registrado con este mismo proveedor en una factura en borrador o cancelada"
+msgstr ""
+"NCF Duplicado en otra Factura\n"
+"\n"
+"El comprobante *{}* ya se encuentra registrado con este mismo proveedor en una factura en borrador o cancelada"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+msgid "NCF Manager Search"
+msgstr "NCF Manager Search"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:214
+#: code:addons/ncf_manager/wizard/account_invoice_refund.py:154
+#, python-format
+msgid ""
+"NCF NO pasÃ³ validaciÃ³n en DGII\n"
+"\n"
+"Â¡El nÃºmero de comprobante *{}* del proveedor *{}* no pasÃ³ la validaciÃ³n en DGII! Verifique que el NCF y el RNC del proveedor estÃ©n correctamente digitados, o si los nÃºmeros de ese NCF se le agotaron al proveedor"
+msgstr ""
+"NCF NO pasÃ³ validaciÃ³n en DGII\n"
+"\n"
+"Â¡El nÃºmero de comprobante *{}* del proveedor *{}* no pasÃ³ la validaciÃ³n en DGII! Verifique que el NCF y el RNC del proveedor estÃ©n correctamente digitados, o si los nÃºmeros de ese NCF se le agotaron al proveedor"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_form
+msgid "NCF Sequence"
+msgstr "Secuencia de NCF"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_tree_view
+msgid "NCF Sequences"
+msgstr "Secuencias de NCF"
+
+#. module: ncf_manager
+#: model:ir.actions.act_window,name:ncf_manager.action_ncf_manager_view
+#: model:ir.model,name:ncf_manager.model_ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_ncf_id
+#: model:ir.model.fields,field_description:ncf_manager.field_ir_sequence_ncf_id
+#: model:ir.ui.menu,name:ncf_manager.ncf_manager_structure
+msgid "NCF Structure"
+msgstr "Estructura de NCF"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_type
+msgid "NCF for"
+msgstr "NCF para"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:199
+#: code:addons/ncf_manager/models/account_invoice.py:311
+#, python-format
+msgid ""
+"NCF mal digitado\n"
+"\n"
+"El comprobante *{}* no tiene la estructura correcta valide si lo ha digitado correctamente"
+msgstr ""
+"NCF mal digitado\n"
+"\n"
+"El comprobante *{}* no tiene la estructura correcta valide si lo ha digitado correctamente"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_sale_fiscal_type
+msgid "NCF para"
+msgstr "NCF para"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/ncf_manager.py:71
+#, python-format
+msgid "New"
+msgstr "Nuevo"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_number_next
+msgid "Next Number"
+msgstr "Número siguiente"
+
+#. module: ncf_manager
+#: selection:account.tax,purchase_tax_type:0
+msgid "No Deducible"
+msgstr "No Deducible"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:259
+#, python-format
+msgid "No existe un Diario de Gastos Menores, debe crear uno."
+msgstr "No existe un Diario de Gastos Menores, debe crear uno."
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/wizard/account_invoice_refund.py:92
+#, python-format
+msgid "No puede hacer un descuento mayor al saldo de la factura."
+msgstr "No puede hacer un descuento mayor al saldo de la factura."
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:183
+#, python-format
+msgid ""
+"No puede validar una factura para RegÃ­men Especial  con ITBIS/ISC.\n"
+"\n"
+"Consulte Norma General 05-19, Art. 3 de la DGII"
+msgstr ""
+"No puede validar una factura para RegÃ­men Especial  con ITBIS/ISC.\n"
+"\n"
+"Consulte Norma General 05-19, Art. 3 de la DGII"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:367
+#, python-format
+msgid "No se puede validar una factura cuyo monto total sea igual a 0."
+msgstr "No se puede validar una factura cuyo monto total sea igual a 0."
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_partner_form
+msgid "Nombre, RNC o Cédula"
+msgstr "Nombre, RNC o Cédula"
+
+#. module: ncf_manager
+#: selection:account.journal,payment_form:0
+msgid "Otras Formas de Venta"
+msgstr "Otras Formas de Venta"
+
+#. module: ncf_manager
+#: selection:account.tax,isr_retention_type:0
+msgid "Otras Rentas"
+msgstr "Otras Rentas"
+
+#. module: ncf_manager
+#: selection:account.journal,purchase_type:0
+msgid "Otros (sin NCF)"
+msgstr "Otros (sin NCF)"
+
+#. module: ncf_manager
+#: selection:account.journal,purchase_type:0
+#: selection:ncf.manager,purchase_type:0
+msgid "Pagos al Exterior"
+msgstr "Pagos al Exterior"
+
+#. module: ncf_manager
+#: selection:account.tax,purchase_tax_type:0
+msgid "Pagos al Exterior (Ley 253-12)"
+msgstr "Pagos al Exterior (Ley 253-12)"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:409
+#, python-format
+msgid "Para poder emitir una NC mayor a  RD$250,000 se requiere que el  cliente tenga RNC o CÃ©dula."
+msgstr "Para poder emitir una NC mayor a  RD$250,000 se requiere que el  cliente tenga RNC o CÃ©dula."
+
+#. module: ncf_manager
+#: selection:account.journal,payment_form:0
+msgid "Permuta"
+msgstr "Permuta"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:206
+#, python-format
+msgid ""
+"Proveedor sin RNC/CÃ©d\n"
+"\n"
+"El proveedor *{}* no tiene RNC o CÃ©dula y es requerido para registrar compras Fiscales"
+msgstr ""
+"Proveedor sin RNC/CÃ©d\n"
+"\n"
+"El proveedor *{}* no tiene RNC o CÃ©dula y es requerido para registrar compras Fiscales"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+#: selection:ncf.manager,type:0
+msgid "Purchase"
+msgstr "Compra"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_purchase_type
+msgid "Purchase type"
+msgstr "Tipo de Compra"
+
+#. module: ncf_manager
+#: sql_constraint:ncf.manager:0
+msgid "Purchase type must be unique per company!"
+msgstr "El tipo de compra debe ser único por compañía!"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_partner_form
+msgid "RNC/Cédula"
+msgstr "RNC/Cédula"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_account_invoice_form
+msgid "Razón de Cancelación:<br/>"
+msgstr "Razón de Cancelación:<br/>"
+
+#. module: ncf_manager
+#: selection:account.invoice,sale_fiscal_type:0
+#: selection:ncf.manager,sale_type:0 selection:res.partner,sale_fiscal_type:0
+msgid "Regímenes Especiales"
+msgstr "Regímenes Especiales"
+
+#. module: ncf_manager
+#: selection:account.tax,isr_retention_type:0
+msgid "Rentas Presuntas"
+msgstr "Rentas Presuntas"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_res_currency_res_currency_rate_id
+msgid "Res Currency Rate"
+msgstr "Res Currency Rate"
+
+#. module: ncf_manager
+#: selection:account.tax,isr_retention_type:0
+msgid "Retención por Proveedores del Estado"
+msgstr "Retención por Proveedores del Estado"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+#: selection:ncf.manager,type:0
+msgid "Sale"
+msgstr "Venta"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_sale_type
+msgid "Sale type"
+msgstr "Tipo de venta"
+
+#. module: ncf_manager
+#: sql_constraint:ncf.manager:0
+msgid "Sale type must be unique per company!"
+msgstr "El tipo de venta debe ser único por compañía!"
+
+#. module: ncf_manager
+#. openerp-web
+#: code:addons/ncf_manager/static/src/xml/ncf_manager.xml:7
+#, python-format
+msgid "Search cities..."
+msgstr "Buscar ciudades ..."
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid "Seleccione una opción"
+msgstr "Seleccione una opción"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/wizard/account_invoice_cancel.py:56
+#, python-format
+msgid "Selected invoice(s) cannot be cancelled as they are already in 'Cancelled' or 'Done' state."
+msgstr "Selected invoice(s) cannot be cancelled as they are already in 'Cancelled' or 'Done' state."
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_sequence_id
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_form
+msgid "Set to draft"
+msgstr "Establecer a Borrador"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:388
+#, python-format
+msgid "Si el monto es mayor a RD$250,000 el cliente debe tener un RNC o CÃ©d para emitir la factura"
+msgstr "Si el monto es mayor a RD$250,000 el cliente debe tener un RNC o CÃ©d para emitir la factura"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_ncf_manager_state
+msgid "State"
+msgstr "Estado"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+msgid "Status"
+msgstr "Estatus"
+
+#. module: ncf_manager
+#: selection:account.journal,payment_form:0
+msgid "Tarjeta Crédito / Débito"
+msgstr "Tarjeta Crédito / Débito"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_invoice_rate
+msgid "Tasa"
+msgstr "Tasa"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_account_tax
+msgid "Tax"
+msgstr "Tax"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/ncf_manager.py:282
+#, python-format
+msgid "This invoice type must be a refund type."
+msgstr "This invoice type must be a refund type."
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_cancel_anulation_type
+msgid "Tipo de Anulación"
+msgstr "Tipo de Anulación"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_purchase_type
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_refund_journal_purchase_type
+#: model:ir.model.fields,field_description:ncf_manager.field_account_journal_purchase_type
+msgid "Tipo de Compra"
+msgstr "Tipo de Compra"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_account_expense_type
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_expense_type
+msgid "Tipo de Costos y Gastos"
+msgstr "Tipo de Costos y Gastos"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_tax_purchase_tax_type
+msgid "Tipo de Impuesto en Compra"
+msgstr "Tipo de Impuesto en Compra"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_account_income_type
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_income_type
+msgid "Tipo de Ingreso"
+msgstr "Tipo de Ingreso"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_tax_isr_retention_type
+msgid "Tipo de Retención en ISR"
+msgstr "Tipo de Retención en ISR"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_anulation_type
+msgid "Tipo de anulación"
+msgstr "Tipo de anulación"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_res_partner_sale_fiscal_type
+#: model:ir.model.fields,field_description:ncf_manager.field_res_users_sale_fiscal_type
+msgid "Tipo de comprobante"
+msgstr "Tipo de comprobante"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_res_partner_expense_type
+#: model:ir.model.fields,field_description:ncf_manager.field_res_users_expense_type
+msgid "Tipo de gasto"
+msgstr "Tipo de gasto"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_search_view
+msgid "Type"
+msgstr "Tipo"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid ""
+"Utilice esta opción\n"
+"                                            si desea crea una nota de\n"
+"                                            crédito en estado borrador idéntica\n"
+"                                            a la factura para luego ser modificada."
+msgstr ""
+"Utilice esta opción\n"
+"                                            si desea crea una nota de\n"
+"                                            crédito en estado borrador idéntica\n"
+"                                            a la factura para luego ser modificada."
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid ""
+"Utilice esta opción si desea aplicar una nota de débito a una factura o\n"
+"                                            a\n"
+"                                            una nota de crédito, La nota de débito será creada, validada y\n"
+"                                            reconciliada. No podrá modificar la nota de débito."
+msgstr ""
+"Utilice esta opción si desea aplicar una nota de débito a una factura o\n"
+"                                            a\n"
+"                                            una nota de crédito, La nota de débito será creada, validada y\n"
+"                                            reconciliada. No podrá modificar la nota de débito."
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.view_account_invoice_refund
+msgid ""
+"Utilice esta opción si desea crea una nota de\n"
+"                                            crédito para aplicar un descuento, La nota de crédito será creada,\n"
+"                                            validada\n"
+"                                            y reconciliada Con la factura. No podrá modificar la nota de crédito."
+msgstr ""
+"Utilice esta opción si desea crea una nota de\n"
+"                                            crédito para aplicar un descuento, La nota de crédito será creada,\n"
+"                                            validada\n"
+"                                            y reconciliada Con la factura. No podrá modificar la nota de crédito."
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_journal_ncf_remote_validation
+msgid "Validar con DGII"
+msgstr "Validar con DGII"
+
+#. module: ncf_manager
+#: model:ir.ui.view,arch_db:ncf_manager.ncf_manager_form
+msgid "Validate"
+msgstr "Validar"
+
+#. module: ncf_manager
+#: model:ir.model.fields,field_description:ncf_manager.field_account_invoice_ncf_expiration_date
+msgid "Válido hasta"
+msgstr "Válido hasta"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:537
+#, python-format
+msgid "You have not defined an NCF structure for this voucher."
+msgstr "No se ha definido una estructura de NCF para este comprobante!"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/ncf_manager.py:220
+#, python-format
+msgid "You only can delete a record in draft state."
+msgstr "Solo puede eliminar un registro en estado Borrador."
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_ir_sequence
+msgid "ir.sequence"
+msgstr "ir.sequence"
+
+#. module: ncf_manager
+#: model:ir.model,name:ncf_manager.model_ir_sequence_date_range
+msgid "ir.sequence.date_range"
+msgstr "ir.sequence.date_range"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:402
+#, python-format
+msgid "Â¡Para Remesas al Exterior el Proveedor debe tener paÃ­s diferente a RepÃºblica Dominicana!"
+msgstr "Â¡Para Remesas al Exterior el Proveedor debe tener paÃ­s diferente a RepÃºblica Dominicana!"
+
+#. module: ncf_manager
+#: code:addons/ncf_manager/models/account_invoice.py:396
+#, python-format
+msgid "Â¡Para este tipo de Compra el Proveedor debe de tener un RNC/CÃ©dula/NIT establecido!"
+msgstr "Â¡Para este tipo de Compra el Proveedor debe de tener un RNC/CÃ©dula/NIT establecido!"
+
+#. module: ncf_manager
+#: selection:account.invoice,sale_fiscal_type:0
+#: selection:ncf.manager,sale_type:0 selection:res.partner,sale_fiscal_type:0
+msgid "Único Ingreso"
+msgstr "Único Ingreso"
+
 #. module: account
 #: model:ir.ui.menu,name:account.menu_finance
 #: model:ir.ui.view,arch_db:account.product_template_form_view

--- a/ncf_manager/models/__init__.py
+++ b/ncf_manager/models/__init__.py
@@ -3,3 +3,4 @@ from . import res_currency
 from . import account_invoice
 from . import res
 from . import ir_sequence
+from . import ncf_manager

--- a/ncf_manager/models/account.py
+++ b/ncf_manager/models/account.py
@@ -38,7 +38,6 @@ class AccountJournal(models.Model):
     ],
         string="Tipo de Compra",
         default="others")
-
     payment_form = fields.Selection(
         [("cash", "Efectivo"),
          ("bank", u"Cheque / Transferencia / Depósito"),

--- a/ncf_manager/models/account.py
+++ b/ncf_manager/models/account.py
@@ -1,6 +1,7 @@
 # © 2018 Gustavo Valverde <gustavo@iterativo.do>
 # © 2018 Eneldo Serrata <eneldo@marcos.do>
 # © 2018 Andrés Rodríguez <andres@iterativo.do>
+# © 2019 Yasmany Castillo <yasmany003@gmail.com>
 
 # This file is part of NCF Manager.
 
@@ -23,11 +24,6 @@ from odoo import models, fields, api
 class AccountJournal(models.Model):
     _inherit = "account.journal"
 
-    @api.depends("ncf_control")
-    def check_ncf_ready(self):
-        self.ensure_one()
-        self.ncf_ready = len(self.date_range_ids) > 1
-
     purchase_type = fields.Selection([
         ("normal", "Compras Fiscales"),
         ("minor", "Gastos Menores"),
@@ -48,39 +44,13 @@ class AccountJournal(models.Model):
          ("others", "Otras Formas de Venta")],
         string="Forma de Pago",
         oldname="ipf_payment_type")
-
     ncf_remote_validation = fields.Boolean("Validar con DGII", default=False)
-
-    ncf_control = fields.Boolean(related="sequence_id.ncf_control",
-                                 readonly=False)
-    prefix = fields.Char(related="sequence_id.prefix", readonly=False)
-    date_range_ids = fields.One2many(related="sequence_id.date_range_ids",
-                                     readonly=False)
-    ncf_ready = fields.Boolean(compute=check_ncf_ready)
-    special_fiscal_position_id = fields.Many2one(
-        "account.fiscal.position",
-        string=u"Posición fiscal para regímenes especiales.",
-        help=u"Define la posición fiscal por defecto para los clientes que \
-               tienen definido el tipo de comprobante fiscal regímenes \
-               especiales.")
+    ncf_control = fields.Boolean(string="Control de NCF", readonly=False)
 
     @api.onchange("type")
     def onchange_type(self):
         if self.type != 'sale':
             self.ncf_control = False
-
-    @api.multi
-    def create_ncf_sequence(self):
-        if self.ncf_control and len(self.sequence_id.date_range_ids) <= 1:
-            # this method read Selection values from res.partner
-            # sale_fiscal_type fields
-            selection = self.env[
-                "ir.sequence.date_range"].get_sale_fiscal_type_from_partner()
-            for sale_fiscal_type in selection:
-                self.sequence_id.date_range_ids[0].copy(
-                    {'sale_fiscal_type': sale_fiscal_type[0]})
-
-            self.sequence_id.date_range_ids.invalidate_cache()
 
 
 class AccountTax(models.Model):

--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -78,7 +78,6 @@ class AccountInvoice(models.Model):
 
     reference = fields.Char(string='NCF')
     ncf_number = fields.Char(
-        related='ncf_id.number',
         string='Fiscal Number',
         size=11,
         readonly=True,

--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -518,7 +518,10 @@ class AccountInvoice(models.Model):
         Search and establish the NCF structure corresponding to the
         type of voucher.
         """
-        domain = [('company_id', '=', self.company_id.id)]
+        domain = [
+            ('company_id', '=', self.company_id.id),
+            ('journal_id', '=', self.journal_id.id)
+        ]
         ncf_structure = False
         if self.type in ['out_invoice','out_refund']:
             domain.append(('type', '=', 'sale'))
@@ -530,5 +533,8 @@ class AccountInvoice(models.Model):
         ncf_id = self.env['ncf.manager'].search(domain, limit=1)
         if ncf_id:
             ncf_structure = ncf_id.id
+        else:
+            raise ValidationError(_("You have not defined an NCF structure "
+                                    "for this voucher."))
 
         return self.update({'ncf_id': ncf_structure})

--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -244,6 +244,7 @@ class AccountInvoice(models.Model):
     @api.onchange('journal_id', 'partner_id')
     def onchange_journal_id(self):
         res = super(AccountInvoice, self)._onchange_journal_id()
+
         if self.journal_id.type == 'purchase':
             self._set_ncf_structure(self.purchase_type)
             if self.journal_id.purchase_type == "minor":

--- a/ncf_manager/models/ir_sequence.py
+++ b/ncf_manager/models/ir_sequence.py
@@ -41,6 +41,11 @@ class IrSequence(models.Model):
     }
 
     ncf_control = fields.Boolean("Control de NCF", default=False)
+    ncf_id = fields.Many2one(
+        comodel_name='ncf.manager',
+        string="NCF Structure",
+        readonly=True,
+    )
 
     def get_next_char(self, number_next):
         sale_fiscal_type = self._context.get("sale_fiscal_type", False)

--- a/ncf_manager/models/ir_sequence.py
+++ b/ncf_manager/models/ir_sequence.py
@@ -1,5 +1,6 @@
 # © 2015-2018 Eneldo Serrata <eneldo@marcos.do>
 # © 2017-2018 Gustavo Valverde <gustavo@iterativo.do>
+# © 2019 Yasmany Castillo <yasmany003@gmail.com>
 
 # This file is part of NCF Manager.
 
@@ -22,96 +23,8 @@ from odoo import models, fields, api
 class IrSequence(models.Model):
     _inherit = 'ir.sequence'
 
-    ncf_padding = fields.Integer(required=True,
-                                 default=8,
-                                 help="Padding legally use by NCF sequences")
-
-    ncf_dict = {
-        "fiscal": "01",
-        "final": "02",
-        "gov": "15",
-        "special": "14",
-        "unico": '12',
-        "export": '16',
-        "debit_note": "03",
-        "credit_note": "04",
-        "minor": "13",
-        "informal": "11",
-        "exterior": "17",
-    }
-
-    ncf_control = fields.Boolean("Control de NCF", default=False)
     ncf_id = fields.Many2one(
         comodel_name='ncf.manager',
         string="NCF Structure",
         readonly=True,
     )
-
-    def get_next_char(self, number_next):
-        sale_fiscal_type = self._context.get("sale_fiscal_type", False)
-        if sale_fiscal_type:
-            return 'B' + self.ncf_dict[
-                sale_fiscal_type] + '%%0%sd' % self.ncf_padding % number_next
-        return super(IrSequence, self).get_next_char(number_next)
-
-    def _next(self):
-        """ Returns the next number in the preferred sequence in all the
-         ones given in self."""
-        sale_fiscal_type = self._context.get("sale_fiscal_type", False)
-        dt = fields.Date.today()
-
-        if sale_fiscal_type:
-            if not self.use_date_range:
-                return self._next_do()
-            # date mode
-            if self._context.get('ir_sequence_date'):
-                dt = self._context.get('ir_sequence_date')
-
-            seq_date = self.env['ir.sequence.date_range'].search(
-                [('sale_fiscal_type', '=', sale_fiscal_type),
-                 ('sequence_id', '=', self.id), ('date_from', '<=', dt),
-                 ('date_to', '>=', dt)],
-                limit=1)
-            if not seq_date:
-                seq_date = self._create_date_range_seq(dt)
-            return seq_date.with_context(
-                ir_sequence_date_range=seq_date.date_from)._next()
-        else:
-            # date mode
-            if self._context.get('ir_sequence_date'):
-                dt = self._context.get('ir_sequence_date')
-
-            seq_date = self.env['ir.sequence.date_range'].search(
-                [('sale_fiscal_type', '=', False),
-                 ('sequence_id', '=', self.id), ('date_from', '<=', dt),
-                 ('date_to', '>=', dt)],
-                limit=1)
-            if seq_date:
-                return seq_date.with_context(
-                    ir_sequence_date_range=seq_date.date_from)._next()
-            return super(IrSequence, self)._next()
-
-    @api.multi
-    def write(self, vals):
-        if self._context.get("params", {}).get("model",
-                                               {}) == "account.invoice":
-            return True
-
-        return super(IrSequence, self).write(vals)
-
-
-class IrSequenceDateRange(models.Model):
-    _inherit = 'ir.sequence.date_range'
-
-    def get_sale_fiscal_type_from_partner(self):
-        return (self.env["res.partner"]._fields['sale_fiscal_type'].selection +
-                [("credit_note", u"Nota de Crédito"),
-                 ("debit_note", u"Nota de Débito"),
-                 ("minor", "Gastos Menores"),
-                 ("informal", "Comprobante de Compras"),
-                 ("exterior", "Pagos al Exterior"),
-                 ])
-
-    sale_fiscal_type = fields.Selection("get_sale_fiscal_type_from_partner",
-                                        string="NCF para")
-    max_number_next = fields.Integer(u"Número Máximo", default=100)

--- a/ncf_manager/models/ncf_manager.py
+++ b/ncf_manager/models/ncf_manager.py
@@ -1,0 +1,261 @@
+# © 2019 Yasmany Castillo <yasmany003@gmail.com>
+
+# This file is part of NCF Manager.
+
+# NCF Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# NCF Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with NCF Manager.  If not, see <https://www.gnu.org/licenses/>.
+
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError, UserError
+READONLY_STATES = {
+    'draft': [('readonly', False)],
+    'done': [('readonly', True)],
+    'cancel': [('readonly', True)],
+}
+
+NCF_TYPE = {
+    'normal': ('01', 'Compras Fiscales'),
+    'fiscal': ('01', 'Crédito Fiscal'),
+    'final': ('02', 'Consumo'),
+    'debit_note': ('03', 'Nota de Débito'),
+    'credit_note': ('04', 'Nota de Crédito'),
+    'informal': ('11', 'Comprobante de Compras'),
+    'unico': ('12', 'Registro Único de Ingresos'),
+    'minor': ('13', 'Comprobante para Gastos Menores'),
+    'special': ('14', 'Comprobante para Regímenes Especiales'),
+    'gov': ('15', 'Comprobantes Gubernamentales'),
+    'export': ('16', 'Comprobantes para Exportaciones'),
+    'exterior': ('17', 'Comprobantes de Pagos al Exterior'),
+    'import': ('E', 'Comprobante Fiscal Electrónico'),
+}
+
+
+class NcfManager(models.Model):
+    _name = 'ncf.manager'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _description = "NCF Structure"
+    _order = "number_next desc, id desc"
+
+    @api.multi
+    @api.depends('sequence_id')
+    def _compute_has_sequence(self):
+        for ncf in self:
+            ncf.has_sequence = bool(ncf.sequence_id)
+
+    @api.multi
+    @api.depends('state', 'sequence_id')
+    def _compute_sequence_next(self):
+        ''' Set the number_next on the sequence related to the invoice/bill/refund'''
+        for ncf in self:
+            if ncf.state == 'done' and ncf.sequence_id:
+                seq = ncf.sequence_id._get_current_sequence()
+                number_next = seq.number_next_actual
+                sequence = '%%0%sd' % seq.padding % number_next
+                ncf.number_next = seq.prefix + sequence
+
+    name = fields.Char(
+        string='Name',
+        required=True,
+        readonly=True,
+        store=True,
+        copy=False,
+        default=lambda self: _('New'),
+    )
+    number_next = fields.Char(
+        string='Next Number',
+        readonly=True,
+        store=True,
+        copy=False,
+        compute="_compute_sequence_next",
+    )
+    ncf_control = fields.Boolean(
+        string='Control de NCF',
+        default=False,
+        copy=False,
+        readonly=True,
+        states=READONLY_STATES,
+    )
+    type = fields.Selection(
+        string='NCF for',
+        selection=[
+            ("sale", "Sale"),
+            ("purchase", "Purchase"),
+        ],
+        default="",
+        required=True,
+        readonly=True,
+        states=READONLY_STATES,
+    )
+    sale_type = fields.Selection(
+        string='Sale type',
+        selection=[
+            ("final", "Consumo"),
+            ("fiscal", u"Crédito Fiscal"),
+            ("gov", "Gubernamentales"),
+            ("special", u"Regímenes Especiales"),
+            ("unico", u"Único Ingreso"),
+            ("export", u"Exportaciones"),
+            ("credit_note", "Credit Note"),
+        ],
+        default="",
+        copy=False,
+        readonly=True,
+        states=READONLY_STATES,
+    )
+    purchase_type = fields.Selection(
+        string="Purchase type",
+        selection=[
+            ("normal", "Compras Fiscales"),
+            ("minor", "Gastos Menores"),
+            ("informal", "Comprobante de Compras"),
+            ("exterior", "Pagos al Exterior"),
+            ("import", "Importaciones"),
+        ],
+        default="",
+        readonly=True,
+        states=READONLY_STATES,
+        copy=False,
+    )
+    journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        string='Journal',
+        required=True,
+        readonly=True,
+        states=READONLY_STATES,
+    )
+    sequence_id = fields.Many2one(
+        comodel_name='ir.sequence',
+        string='Sequence',
+        readonly=True,
+        required=False,
+    )
+    has_sequence = fields.Boolean(
+        help="Technical field used for usability purposes",
+        compute="_compute_has_sequence",
+    )
+    state = fields.Selection(
+        string="State",
+        selection=[
+            ("draft", "Draft"),
+            ("done", "Done"),
+            ("cancel", "Cancel"),
+        ],
+        default="draft",
+        copy=False,
+    )
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        string='Company',
+        change_default=True,
+        required=True,
+        readonly=True,
+        default=lambda self: self.env['res.company']._company_default_get(
+            'ncf.manager'),
+    )
+    active = fields.Boolean(string='Active', default=True, )
+    invoice_ids = fields.One2many(
+        comodel_name='account.invoice',
+        inverse_name='ncf_id',
+        string='Invoices',
+        required=False,
+        readonly=True,
+    )
+
+    @api.onchange('journal_id', 'type')
+    def _onchange_journal_id(self):
+        journal_domain = [
+            ('active', '=', True),
+            ('company_id', '=', self.env.user.company_id.id),
+        ]
+
+        if self.type:
+            if self.type == 'sale':
+                journal_domain.append(('type', '=', 'sale'))
+                journals = self.journal_id.search(journal_domain)
+            else:
+                journal_domain.append(('type', '=', 'purchase'))
+                journals = self.journal_id.search(journal_domain)
+
+            return {
+                'domain': {
+                    'journal_id': [('id', 'in', journals.ids)]
+                }
+            }
+
+    @api.multi
+    @api.depends('type', 'sale_type', 'purchase_type', 'credit_note_control')
+    def name_get(self):
+        result = []
+        for record in self:
+            type = record.sale_type or record.purchase_type
+            name = NCF_TYPE.get(type)[1]
+            result.append((record.id, name))
+        return result
+
+    @api.model
+    def create(self, values):
+        type = values.get('sale_type') or values.get('purchase_type')
+        values['name'] = NCF_TYPE.get(type)[1]
+        return super(NcfManager, self).create(values)
+
+    @api.multi
+    def unlink(self):
+        """Allow to remove ncf."""
+        for record in self:
+            if record.state != 'draft':
+                raise UserError(
+                    _("You only can delete a record in draft state."))
+            record.unlink()
+
+    @api.multi
+    def action_done(self):
+        return self.write({'state': 'done'})
+
+    @api.multi
+    def action_cancel(self):
+        return self.write({'state': 'cancel'})
+
+    @api.multi
+    def create_sequence(self):
+        """Create a new sequence if not exist for this ncf."""
+        sequence_obj = self.env['ir.sequence']
+        sequence = sequence_obj.search(
+            [
+                ('company_id', '=', self.company_id.id),
+                ('ncf_id', '=', self.id)
+            ],
+        )
+        if sequence:
+            return self.write({'sequence_id': sequence.id})
+
+        sequence_values = {
+            'implementation': 'no_gap',
+            'padding': 8,
+            'number_increment': 1,
+            'use_date_range': False,
+            'company_id': self.company_id.id,
+            'ncf_id': self.id,
+        }
+
+        type = self.sale_type or self.purchase_type
+        sequence_values['name'] = NCF_TYPE.get(type)[1]
+        sequence_values['prefix'] = "B%s" % NCF_TYPE.get(type)[0]
+
+        sequence_id = sequence_obj.create(sequence_values)
+        return self.write({
+            'sequence_id': sequence_id.id,
+            'has_sequence': True,
+        })
+
+
+

--- a/ncf_manager/models/ncf_manager.py
+++ b/ncf_manager/models/ncf_manager.py
@@ -76,13 +76,6 @@ class NcfManager(models.Model):
         copy=False,
         compute="_compute_sequence_next",
     )
-    ncf_control = fields.Boolean(
-        string='Control de NCF',
-        default=False,
-        copy=False,
-        readonly=True,
-        states=READONLY_STATES,
-    )
     type = fields.Selection(
         string='NCF for',
         selection=[

--- a/ncf_manager/security/ir.model.access.csv
+++ b/ncf_manager/security/ir.model.access.csv
@@ -2,4 +2,5 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 account.access_account_journal_user,account.journal,account.model_account_journal,account.group_account_user,1,1,,
 account.access_account_journal_invoice,'account.journal invoice',account.model_account_journal,account.group_account_invoice,1,1,,
 base.access_ir_sequence_group_user,'employee ir_sequence',model_ir_sequence,base.group_user,1,1,,
-base.access_ir_sequence_date_range_group_user,'ir_sequence_date_range group_user',model_ir_sequence_date_range,base.group_user,1,1,,
+access_ncf_manager_user,'NCF Manager Structure',model_ncf_manager,base.group_user,1,0,0,0
+access_ncf_manager_root,'NCF Manager Structure',model_ncf_manager,ncf_manager.group_ncf_manager,1,1,1,1

--- a/ncf_manager/security/security.xml
+++ b/ncf_manager/security/security.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+		
+        <record model="res.groups" id="group_ncf_manager">
+          <field name="name">Manage NCF structure</field>
+      </record>
+
+    </data>
+</odoo>

--- a/ncf_manager/views/account_invoice_view.xml
+++ b/ncf_manager/views/account_invoice_view.xml
@@ -52,7 +52,10 @@
             <field name="move_id" position="before">
                 <field name="origin" groups="base.group_user" attrs="{'invisible': [('type', '=', 'out_refund')]}"/>
             </field>
-
+			
+            <field name="journal_id" position="before">
+                <field name="ncf_id" force_save="1" groups="base.group_user" attrs="{'invisible': [('sale_fiscal_type', '=', False)]}"/>
+            </field>
         </field>
     </record>
 
@@ -120,6 +123,7 @@
                        'invisible':[('purchase_type', 'not in', ['normal', 'minor', 'informal', 'exterior'])],
                        'required': [('purchase_type', 'in', ['normal', 'minor', 'informal', 'exterior'])],
                        'readonly': [('state', '!=', 'draft')]}"/>
+				<field name="ncf_id" force_save="1" groups="account.group_account_user" attrs="{'invisible': [('purchase_type', '=', False)]}"/>
             </field>
 
         </field>

--- a/ncf_manager/views/account_invoice_view.xml
+++ b/ncf_manager/views/account_invoice_view.xml
@@ -33,6 +33,8 @@
                        'invisible':[('ncf_control','!=',True)],
                        'required': [('ncf_control','=',True),('type','=','out_invoice')],
                        'readonly': [('state','!=','draft')]}"/>
+                <field name="ncf_number" string="NCF" readonly="1" attrs="{
+                       'invisible': [('state', '=', 'draft')], 'readonly': [('type', '=', 'in_invoice')]}"/>
                 <field name="reference" string="NCF" readonly="1" attrs="{
                        'invisible': ['|', '|', ('state', '=', 'draft'), ('reference', '=', False), ('ncf_control','=',False)],
                        'readonly': True}"/>
@@ -64,13 +66,12 @@
         <field name="model">account.invoice</field>
         <field name="inherit_id" ref="account.invoice_tree"/>
         <field name="arch" type="xml">
-
-            <xpath expr="//field[@name='reference']" position="attributes">
-                <attribute name="invisible"/>
-                <attribute name="attrs">{"readonly": [["state","not in",["draft"]]]}</attribute>
-                <attribute name="string">NCF</attribute>
-            </xpath>
-
+			<xpath expr="//field[@name='number']" position="after">
+				<field name="ncf_number" string="NCF" attrs="{'readonly': [['state', 'not in', ['draft']]]}"/>
+			</xpath>
+			<xpath expr="//field[@name='user_id']" position="before">
+				<field name="origin_out" attrs="{'invisible': [('type', '!=', 'out_refund')]}"/>
+			</xpath>
         </field>
     </record>
 

--- a/ncf_manager/views/account_view.xml
+++ b/ncf_manager/views/account_view.xml
@@ -5,38 +5,12 @@
         <field name="model">account.journal</field>
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
-
-            <xpath expr="//button[@name='toggle_active']" position="after">
-                <field name="ncf_ready" invisible="1"/>
-                <button class="oe_stat_button" type="object" name="create_ncf_sequence" icon="fa-database"
-                        attrs="{'invisible':['|',('ncf_control','!=',True),('ncf_ready','!=',False)]}" string="Generar NCF">
-                </button>
-            </xpath>
-
             <field name="type" position="after">
                 <field name="ncf_control" attrs="{'invisible': [('type','!=','sale')]}"/>
                 <field name="purchase_type" attrs="{'invisible': [('type','!=','purchase')]}" widget="selection"/>
                 <field name="ncf_remote_validation" attrs="{'invisible': [('type','!=','purchase')]}"/>
                 <field name="payment_form" attrs="{'invisible': [('type','not in',('cash','bank'))], 'required': [('type','in',('cash','bank'))]}"/>
             </field>
-
-            <notebook>
-                <page string="Secuencias NCF" attrs="{'invisible':[('ncf_control','!=',True)]}">
-                    <group>
-                        <field name="prefix"/>
-                        <field name="special_fiscal_position_id"/>
-                    </group>
-                    <field name="date_range_ids">
-                        <tree>
-                            <field name="date_from"/>
-                            <field name="date_to"/>
-                            <field name="number_next_actual"/>
-                            <field name="max_number_next"/>
-                            <field name="sale_fiscal_type"/>
-                        </tree>
-                    </field>
-                </page>
-            </notebook>
         </field>
     </record>
 

--- a/ncf_manager/views/ir_sequence_view.xml
+++ b/ncf_manager/views/ir_sequence_view.xml
@@ -8,12 +8,9 @@
            <field name="model">ir.sequence</field>
            <field name="inherit_id" ref="base.sequence_view"/>
            <field name="arch" type="xml">
-
-               <xpath expr="//tree//field[@name='number_next_actual']" position="after">
-                   <field name="max_number_next"/>
-                   <field name="sale_fiscal_type"/>
+               <xpath expr="//field[@name='implementation']" position="after">
+                   <field name="ncf_id" invisible="1"/>
                </xpath>
-
            </field>
        </record>
 

--- a/ncf_manager/views/ncf_manager_view.xml
+++ b/ncf_manager/views/ncf_manager_view.xml
@@ -27,8 +27,8 @@
             <form string="NCF Sequence">
 				<header>
 					<button name="action_confirm" string="Confirm" class="oe_highlight" states="draft" type="object"/>
-					<button name="action_set_to_draft" string="Set to draft" states="confirmed" type="object"/>
-					<button name="create_sequence" string="Create sequence" class="oe_highlight" states="confirmed" type="object"/>
+					<button name="action_set_to_draft" string="Set to draft" states="confirmed,cancel" type="object"/>
+					<button name="configure" string="Configure" class="oe_highlight" states="confirmed" type="object"/>
 					<button name="action_cancel" string="Cancel" class="oe_highlight" states="done" type="object"/>
 					<button name="action_done" string="Validate" class="oe_highlight" states="confirmed" type="object"/>
 					<field name="state" widget="statusbar" statusbar_visible="draft,confirmed,done,cancel"/>
@@ -41,12 +41,13 @@
 								options='{"terminology": "active"}'/>
 						</button>
                     </div>
-                    <div class="oe_title oe_inline">
-                        <label for="name" class="oe_edit_only"/>
-                        <h1>
-                            <field name="name"/>
-                        </h1>
-                    </div>
+					<div class="oe_title oe_inline">
+						<label for="name" class="oe_edit_only"/>
+						<h1>
+							<field name="name"/>
+						</h1>
+					</div>
+					
                     <group>
 						<group>
                             <field name="type"/>
@@ -57,9 +58,27 @@
 						<group>
 							<field name="journal_id"/>
 							<field name="fiscal_position_id" attrs="{'invisible': ['|',('type', '!=', 'sale'), ('sale_type', '!=', 'special')], 'required': [('sale_type', '=', 'special')]}"/>
-							<field name="sequence_id" options="{'no_open': True}"/>
-							<field name="number_next"/>
+							<field name="sequence_id" options="{'no_open': True}" attrs="{'invisible': [('purchase_type', '=', 'normal')]}"/>
+							<field name="number_next" attrs="{'invisible': [('purchase_type', '=', 'normal')]}"/>
 						</group>
+					</group>
+					<group attrs="{'invisible': [('type', '!=', 'purchase')]}">
+						<div class="alert alert-info info_icon" role="alert">
+							<div attrs="{'invisible': [('purchase_type', '!=', 'normal')]}">
+								<h5>Compras Fiscales</h5>
+								<div>
+									Este tipo de comprobante no conlleva una secuencia exclusiva, ya que el NCF
+									es dado por el Proveedor, por lo tanto el diario seleccionado sera configurado
+									para manejar este tipo de NCF.
+								</div>
+							</div>
+							<div attrs="{'invisible': [('purchase_type', 'not in', ['minor', 'informal'])]}">
+								<h5>Comprobante para Gastos Menores</h5>
+								<div>
+									Este tipo de comprobante tiene una secuencia exclusiva, la cual es provista por la DGII y a la vez requiere que el Diario seleccionado sea adaptado para manejar este tipo de secuencia.
+								</div>
+							</div>
+						</div>
 					</group>
                 </sheet>
                 <div class="oe_chatter">

--- a/ncf_manager/views/ncf_manager_view.xml
+++ b/ncf_manager/views/ncf_manager_view.xml
@@ -15,7 +15,7 @@
 				<field name="type"/>
 				<field name="journal_id"/>
 				<field name="company_id"/>
-				<field name="state" invisible="1"/>
+				<field name="state"/>
             </tree>
         </field>
     </record>
@@ -26,11 +26,11 @@
         <field name="arch" type="xml">
             <form string="NCF Sequence">
 				<header>
+					<field name="has_sequence" invisible="0"/>
 					<button name="action_done" string="Validate" class="oe_highlight" states="draft" type="object"/>
 					<button name="action_cancel" string="Cancel" class="oe_highlight" states="done" type="object"/>
 					<button name="create_sequence" string="Create sequence" class="oe_highlight" states="done" type="object" atrrs="{'invisible': [('has_sequence', '=', True)]"/>
-				    <field name="state" widget="statusbar" statusbar_visible="draft,done,cancel"/>
-				    <field name="has_sequence" invisible="0"/>
+					<field name="state" widget="statusbar" statusbar_visible="draft,done,cancel"/>
 				</header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -72,6 +72,31 @@
             </form>
         </field>
     </record>
+	
+	<record id="ncf_manager_search_view" model="ir.ui.view">
+		<field name="name">ncf.manager.search.view</field>
+		<field name="model">ncf.manager</field>
+		<field name="type">search</field>
+		<field name="arch" type="xml">
+			<search string="NCF Manager Search">
+				<field string="NCF" name="name" filter_domain="[('name', 'ilike', self)]"/>
+				<field string="Company" name="company_id" filter_domain="[('company_id', 'child_of', self)]"/>
+				<field string="Journal" name="journal_id" filter_domain="[('journal_id', 'ilike', self)]"/>
+				<separator/>
+				<filter string="Done" name="state" domain="[('state', '=', 'done')]"/>
+				<filter string="Cancel" name="state" domain="[('state', '=', 'cancel')]"/>
+				<separator/>
+				<filter string="Sale" name="type" domain="[('type', '=', 'sale')]"/>
+				<filter string="Purchase" name="type" domain="[('type', '=', 'purchase')]"/>
+				<group expand="0" string="Group By...">
+					<filter string="Type" context="{'group_by':'type'}"/>
+					<filter string="Journal" context="{'group_by':'journal_id'}"/>
+					<filter string="Company" context="{'group_by':'company_id'}"/>
+					<filter string="Status" context="{'group_by':'state'}"/>
+				</group>
+			</search>
+		</field>
+	</record>
 
     <record id="action_ncf_manager_view" model="ir.actions.act_window">
         <field name="name">NCF Structure</field>
@@ -79,6 +104,7 @@
         <field name="res_model">ncf.manager</field>
         <field name="view_mode">tree,form</field>
         <field name="view_id" ref="ncf_manager_tree_view"/>
+		<field name="search_view_id" ref="ncf_manager_search_view"/>
     </record>
 	
     <menuitem name="NCF Structure"

--- a/ncf_manager/views/ncf_manager_view.xml
+++ b/ncf_manager/views/ncf_manager_view.xml
@@ -60,6 +60,7 @@
                         </group>
 						<group>
 							<field name="journal_id"/>
+							<field name="fiscal_position_id" attrs="{'invisible': ['|',('type', '!=', 'sale'), ('sale_type', '!=', 'special')], 'required': [('sale_type', '=', 'special')]}"/>
 							<field name="sequence_id" options="{'no_open': True}"/>
 							<field name="number_next"/>
 						</group>

--- a/ncf_manager/views/ncf_manager_view.xml
+++ b/ncf_manager/views/ncf_manager_view.xml
@@ -26,11 +26,12 @@
         <field name="arch" type="xml">
             <form string="NCF Sequence">
 				<header>
-					<field name="has_sequence" invisible="0"/>
-					<button name="action_done" string="Validate" class="oe_highlight" states="draft" type="object"/>
+					<button name="action_confirm" string="Confirm" class="oe_highlight" states="draft" type="object"/>
+					<button name="action_set_to_draft" string="Set to draft" states="confirmed" type="object"/>
+					<button name="create_sequence" string="Create sequence" class="oe_highlight" states="confirmed" type="object"/>
 					<button name="action_cancel" string="Cancel" class="oe_highlight" states="done" type="object"/>
-					<button name="create_sequence" string="Create sequence" class="oe_highlight" states="done" type="object" atrrs="{'invisible': [('has_sequence', '=', True)]"/>
-					<field name="state" widget="statusbar" statusbar_visible="draft,done,cancel"/>
+					<button name="action_done" string="Validate" class="oe_highlight" states="confirmed" type="object"/>
+					<field name="state" widget="statusbar" statusbar_visible="draft,confirmed,done,cancel"/>
 				</header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -59,7 +60,7 @@
                         </group>
 						<group>
 							<field name="journal_id"/>
-							<field name="sequence_id"/> <!-- options="{'no_open': True} -->
+							<field name="sequence_id" options="{'no_open': True}"/>
 							<field name="number_next"/>
 						</group>
 					</group>
@@ -82,12 +83,14 @@
 				<field string="NCF" name="name" filter_domain="[('name', 'ilike', self)]"/>
 				<field string="Company" name="company_id" filter_domain="[('company_id', 'child_of', self)]"/>
 				<field string="Journal" name="journal_id" filter_domain="[('journal_id', 'ilike', self)]"/>
+				<filter string="Sale" name="type" domain="[('type', '=', 'sale')]"/>
+				<filter string="Purchase" name="type" domain="[('type', '=', 'purchase')]"/>
+				<separator/>
+				<filter string="Active" name="active" domain="[('active', '=', True)]"/>
+				<filter string="Archived" name="active" domain="[('active', '=', False)]"/>
 				<separator/>
 				<filter string="Done" name="state" domain="[('state', '=', 'done')]"/>
 				<filter string="Cancel" name="state" domain="[('state', '=', 'cancel')]"/>
-				<separator/>
-				<filter string="Sale" name="type" domain="[('type', '=', 'sale')]"/>
-				<filter string="Purchase" name="type" domain="[('type', '=', 'purchase')]"/>
 				<group expand="0" string="Group By...">
 					<filter string="Type" context="{'group_by':'type'}"/>
 					<filter string="Journal" context="{'group_by':'journal_id'}"/>

--- a/ncf_manager/views/ncf_manager_view.xml
+++ b/ncf_manager/views/ncf_manager_view.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+	
+    <!-- Menuitem -->
+	<menuitem name="NCF" id="ncf_manager_root_menu" parent="account.menu_finance_configuration" groups="ncf_manager.group_ncf_manager"/>
+	
+    <!-- Ncf Manager Views -->
+    <record id="ncf_manager_tree_view" model="ir.ui.view">
+        <field name="name">ncf.manager.tree</field>
+        <field name="model">ncf.manager</field>
+        <field name="arch" type="xml">
+            <tree string="NCF Sequences">
+                <field name="name"/>
+				<field name="number_next"/>
+				<field name="type"/>
+				<field name="journal_id"/>
+				<field name="company_id"/>
+				<field name="state" invisible="1"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="ncf_manager_form" model="ir.ui.view">
+        <field name="name">ncf.manager.form</field>
+        <field name="model">ncf.manager</field>
+        <field name="arch" type="xml">
+            <form string="NCF Sequence">
+				<header>
+					<button name="action_done" string="Validate" class="oe_highlight" states="draft" type="object"/>
+					<button name="action_cancel" string="Cancel" class="oe_highlight" states="done" type="object"/>
+					<button name="create_sequence" string="Create sequence" class="oe_highlight" states="done" type="object" atrrs="{'invisible': [('has_sequence', '=', True)]"/>
+				    <field name="state" widget="statusbar" statusbar_visible="draft,done,cancel"/>
+				    <field name="has_sequence" invisible="0"/>
+				</header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+						<button name="toggle_active" type="object"
+								class="oe_stat_button" icon="fa-archive">
+							<field name="active" widget="boolean_button"
+								options='{"terminology": "active"}'/>
+						</button>
+                    </div>
+                    <div class="oe_title oe_inline">
+                        <label for="name" class="oe_edit_only"/>
+                        <h1>
+                            <field name="name"/>
+                        </h1>
+						<div>
+							<field name="ncf_control"/>
+							<label for="ncf_control"/>
+						</div>
+                    </div>
+                    <group>
+						<group>
+                            <field name="type"/>
+                            <field name="sale_type" attrs="{'invisible': [('type', '!=', 'sale')], 'required': [('type', '=', 'sale')]}"/>
+                            <field name="purchase_type" attrs="{'invisible': [('type', '!=', 'purchase')], 'required': [('type', '=', 'purchase')]}"/>
+                            <field name="company_id"/>
+                        </group>
+						<group>
+							<field name="journal_id"/>
+							<field name="sequence_id"/> <!-- options="{'no_open': True} -->
+							<field name="number_next"/>
+						</group>
+					</group>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="activity_ids" widget="mail_activity"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_ncf_manager_view" model="ir.actions.act_window">
+        <field name="name">NCF Structure</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">ncf.manager</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="ncf_manager_tree_view"/>
+    </record>
+	
+    <menuitem name="NCF Structure"
+        id="ncf_manager_structure"
+        parent="ncf_manager_root_menu"
+        action="action_ncf_manager_view"
+        groups="ncf_manager.group_ncf_manager"
+        sequence="1"/>
+</odoo>

--- a/ncf_manager/views/ncf_manager_view.xml
+++ b/ncf_manager/views/ncf_manager_view.xml
@@ -46,10 +46,6 @@
                         <h1>
                             <field name="name"/>
                         </h1>
-						<div>
-							<field name="ncf_control"/>
-							<label for="ncf_control"/>
-						</div>
                     </div>
                     <group>
 						<group>

--- a/ncf_manager/wizard/account_invoice_refund.py
+++ b/ncf_manager/wizard/account_invoice_refund.py
@@ -1,5 +1,6 @@
 # © 2015-2018 Eneldo Serrata <eneldo@marcos.do>
 # © 2017-2018 Gustavo Valverde <gustavo@iterativo.do>
+# © 2019 Yasmany Castillo <yasmany003@@gmail.com>
 
 # This file is part of NCF Manager.
 
@@ -104,15 +105,12 @@ class AccountInvoiceRefund(models.TransientModel):
                         {"invoice_line_ids": [(6, False, [new_line.id])]})
 
                     if mode == "debit":
-
                         vals.update({"is_nd": True})
-
                         if refund.type == "out_refund":
                             vals.update({"type": "out_invoice"})
                             if result.get("domain", False):
                                 result["domain"][0] = ('type', '=',
                                                        'out_invoice')
-
                         if refund.type == "in_refund":
                             vals.update({
                                 "type": "in_invoice",
@@ -125,6 +123,9 @@ class AccountInvoiceRefund(models.TransientModel):
                                         self.supplier_ncf
                                 })
 
+                ncf_refund = origin_inv.ncf_id.get_ncf_structure_for_refund(
+                    refund.type)
+                vals['ncf_id'] = ncf_refund.id
                 refund.write(vals)
 
         return result


### PR DESCRIPTION
[ADD] ncf.manager: Nuevo modelo para vistas personalizadas de las secuencias

Antes de este commit las secuencias de comprobantes se manejan directamente en los diarios, estando la mayoria en el diario de Facturas de Clientes, lo cual no permite poder tener un control directo sobre ellas, y a la vez a ocasionado un poco de confusion en los usuarios al momento de configarlas.

A la vez la secuencia para muchos comprobantes se realiza usando un mismo diario, para el caso de los comprobantes de Ventas (Consumo, Fiscal, ND). 

Luego de este commit los NCF tendran un modelo propio, con vistas propias que permiten una rapida configuración. Cada secuencia tendra un diario especifico para manejar las secuencias, la secuencia seran creadas directamente desde la vista con las configuraciones correspondiente al tipo de NCF, lo que permitira que el usuario final no tenga que crear o modificar una secuencia. Estara adaptado para soportar multi empresa y con un permiso para determinar que usuario podra acceder y manajar dichas secuencias.