### PR TITLE
Enforce max numbers on ncf_pos

### DIFF
--- a/ncf_pos/models/pos_order.py
+++ b/ncf_pos/models/pos_order.py
@@ -269,10 +269,11 @@ class PosOrder(models.Model):
                     raise ValidationError(
                         _("You have not specified a sales journal"))
                 elif not is_return_order:
-                    # If max NCF number reached return max_ncf_number_reached message,
-                    # POS will use this message to display an error popup to the user
-                    # prompting them to get help to extend the max number in the sequence.
-                    # If max number is not reached get next number in sequence and return.
+                    # If max NCF number reached return max_ncf_number_reached
+                    # message, POS will use this message to display an error
+                    # popup to the user prompting them to get help to extend
+                    # the max number in the sequence. If max number is not
+                    # reached get next number in sequence and return.
                     sequence = self.env['ir.sequence.date_range'].search([
                         ('sequence_id', '=', journal_id.sequence_id.id),
                         ('sale_fiscal_type', '=', sale_fiscal_type)
@@ -285,8 +286,8 @@ class PosOrder(models.Model):
                         sale_fiscal_type=sale_fiscal_type).next_by_id()
                 elif is_return_order:
                     sequence = self.env['ir.sequence.date_range'].search([
-                            ('sequence_id', '=', journal_id.sequence_id.id),
-                            ('sale_fiscal_type', '=', 'credit_note')
+                        ('sequence_id', '=', journal_id.sequence_id.id),
+                        ('sale_fiscal_type', '=', 'credit_note')
                     ])[0]
                     if sequence.number_next_actual > sequence.max_number_next:
                         return 'max_ncf_number_reached'

--- a/ncf_pos/models/pos_order.py
+++ b/ncf_pos/models/pos_order.py
@@ -267,10 +267,28 @@ class PosOrder(models.Model):
                     raise ValidationError(
                         _("You have not specified a sales journal"))
                 elif not is_return_order:
+                    # If max NCF number reached return max_ncf_number_reached message,
+                    # POS will use this message to display an error popup to the user
+                    # prompting them to get help to extend the max number in the sequence.
+                    # If max number is not reached get next number in sequence and return.
+                    sequence = self.env['ir.sequence.date_range'].search([
+                        ('sequence_id', '=', journal_id.sequence_id.id),
+                        ('sale_fiscal_type', '=', sale_fiscal_type)
+                    ])[0]
+                    if sequence.number_next_actual > sequence.max_number_next:
+                        return 'max_ncf_number_reached'
+
                     ncf = journal_id.sequence_id.with_context(
                         ir_sequence_date=fields.Date.today(),
                         sale_fiscal_type=sale_fiscal_type).next_by_id()
                 elif is_return_order:
+                    sequence = self.env['ir.sequence.date_range'].search([
+                            ('sequence_id', '=', journal_id.sequence_id.id),
+                            ('sale_fiscal_type', '=', 'credit_note')
+                    ])[0]
+                    if sequence.number_next_actual > sequence.max_number_next:
+                        return 'max_ncf_number_reached'
+
                     ncf = journal_id.sequence_id.with_context(
                         ir_sequence_date=fields.Date.today(),
                         sale_fiscal_type="credit_note").next_by_id()

--- a/ncf_pos/static/src/js/screens.js
+++ b/ncf_pos/static/src/js/screens.js
@@ -917,6 +917,9 @@ odoo.define('ncf_pos.screens', function (require) {
                 });
 
                 dfd.done(function (next_ncf) {
+                    if (next_ncf && (next_ncf.slice(0,1)) === 'B') {
+                        order.max_ncf_number_reached = false;
+                    }
                     var ncfs = self.pos.db.load('ncfs', []);
 
                     order.ncf = next_ncf;
@@ -977,8 +980,18 @@ odoo.define('ncf_pos.screens', function (require) {
                     } else {
                         this.get_next_ncf(order)
                             .done(function () {
-                                self.finalize_validation();
-                                self.orderValidationDate = null;
+                                if (order.ncf === 'max_ncf_number_reached' || order.max_ncf_number_reached) {
+                                    order.max_ncf_number_reached = true;
+                                    self.gui.show_popup('error', {
+                                        'title': 'Limite Máximo para Secuencia de NCF Excedido',
+                                        'body': 'Se a alcanzado el limite maximo para el tipo de NCF seleccionado: ' +
+                                                order.get_client().sale_fiscal_type +
+                                                '. Puede pedir ayuda para extender la secuencia permitida y validar la orden nuevamente.\n\n',
+                                    });
+                                } else {
+                                    self.finalize_validation();
+                                    self.orderValidationDate = null;
+                                }
                             }).fail(function () {
                                 self.gui.show_popup('error', {
                                     'title': 'No se pudo realizar la conexión con el servidor',


### PR DESCRIPTION
Impacted versions
V10, V11, v12

Steps to reproduce
Configurar un numero máximo en el diario de factura. Sobrepasar este numero.

Current behavior
Sobrepasa el número máximo.

Expected behavior
Le ponga un freno al usuario. Talvez tener casilla para override en punto de ventas, para evitar conflictos en facturación.

Video/Screenshot link (optional)