### PR TITLE
[IMP] l10n_do_accounting: restrict credit notes by user group

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -25,6 +25,7 @@
     # always loaded
     'data': [
         'security/ir.model.access.csv',
+        'security/res_groups.xml',
         'data/ir_cron_data.xml',
         'data/account_fiscal_type_data.xml',
         'views/account_fiscal_sequence_views.xml',

--- a/l10n_do_accounting/security/res_groups.xml
+++ b/l10n_do_accounting/security/res_groups.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="0">
+
+    <record id="credit_note_group" model="res.groups">
+        <field name="name">Can create Credit Notes</field>
+    </record>
+
+    <record id="base.group_system" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('l10n_do_accounting.credit_note_group'))]"/>
+    </record>
+
+    <record id="base.user_admin" model="res.users">
+        <field name="implied_ids" eval="[(4, ref('l10n_do_accounting.credit_note_group'))]"/>
+    </record>
+
+    <record id="account.group_account_user" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('l10n_do_accounting.credit_note_group'))]"/>
+    </record>
+
+    <record id="account.group_account_manager" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('l10n_do_accounting.credit_note_group'))]"/>
+    </record>
+
+</odoo>

--- a/l10n_do_accounting/views/account_invoice_views.xml
+++ b/l10n_do_accounting/views/account_invoice_views.xml
@@ -19,6 +19,9 @@
                     Fiscal Sequence depleted.
                 </div>
             </xpath>
+            <xpath expr="//button[@name='%(account.action_account_invoice_refund)d']" position="attributes">
+                <attribute name="groups">l10n_do_accounting.credit_note_group</attribute>
+            </xpath>
             <!--<xpath expr="//h1[@class='mt0']" position="before">-->
                 <!--<h1 class="mt0">-->
                     <!--<field name="reference" -->
@@ -86,6 +89,9 @@
                     Fiscal Sequence depleted.
                 </div>
             </xpath>
+            <xpath expr="//button[@name='%(account.action_account_invoice_refund)d']" position="attributes">
+                <attribute name="groups">l10n_do_accounting.credit_note_group</attribute>
+            </xpath>
 
             <!--<xpath expr="//sheet/div/h1[@class='mt0']" position="before">-->
                 <!--<h1 class="mt0">-->
@@ -147,4 +153,13 @@
 
         </field>
     </record>
+
+    <menuitem id="account.menu_action_invoice_out_refund"
+              groups="l10n_do_accounting.credit_note_group"
+    />
+
+    <menuitem id="account.menu_action_invoice_in_refund"
+              groups="l10n_do_accounting.credit_note_group"
+    />
+
 </odoo>


### PR DESCRIPTION
In order to avoid possible fraud, access to the creation of credit notes was restricted with a user group.