### PR TITLE
[IMP] l10n_do_accounting: finish fiscal invoice unitests

### DIFF
--- a/l10n_do_accounting/demo/account_fiscal_sequence_demo.xml
+++ b/l10n_do_accounting/demo/account_fiscal_sequence_demo.xml
@@ -77,6 +77,12 @@
         <field name="sequence_start" eval="1"/>
         <field name="sequence_end" eval="100"/>
     </record>
+    <record id="purchase_credit_note_demo" model="account.fiscal.sequence">
+        <field name="name">8001695033</field>
+        <field name="fiscal_type_id" ref="l10n_do_accounting.fiscal_type_purchase_credit_note"/>
+        <field name="sequence_start" eval="1"/>
+        <field name="sequence_end" eval="100"/>
+    </record>
 
 
     <data noupdate="1">
@@ -95,6 +101,7 @@
             ref('l10n_do_accounting.informal_demo'),
             ref('l10n_do_accounting.minor_demo'),
             ref('l10n_do_accounting.exterior_demo'),
+            ref('l10n_do_accounting.purchase_credit_note_demo'),
             ]"/>
         </function>
     </data>

--- a/l10n_do_accounting/models/account_invoice.py
+++ b/l10n_do_accounting/models/account_invoice.py
@@ -203,7 +203,8 @@ class AccountInvoice(models.Model):
                 # on invoice validate.
                 inv._compute_fiscal_sequence()
 
-                if not inv.fiscal_sequence_id:
+                if not inv.fiscal_sequence_id and \
+                        inv.fiscal_type_id.internal_generate:
                     raise ValidationError(
                         _('There is not active Fiscal Sequence for this type'
                           'of document.'))

--- a/l10n_do_accounting/tests/common.py
+++ b/l10n_do_accounting/tests/common.py
@@ -47,6 +47,7 @@ class AccountInvoiceCommon(CommonSetup):
         self.journal_obj = self.env['account.journal']
         self.partner_obj = self.env['res.partner']
         self.fiscal_type_obj = self.env['account.fiscal.type']
+        self.invoice_refund_obj = self.env['account.invoice.refund']
 
         self.sale_journal = False
         self.purchase_journal = False
@@ -82,6 +83,8 @@ class AccountInvoiceCommon(CommonSetup):
             'l10n_do_accounting.fiscal_type_consumo')
         self.fiscal_type_informal = self.ref(
             'l10n_do_accounting.fiscal_type_informal')
+        self.fiscal_type_cn = self.ref(
+            'l10n_do_accounting.fiscal_type_credit_note')
 
         # Invoice lines
         account_id = self.env['account.account'].search(

--- a/l10n_do_accounting/tests/common.py
+++ b/l10n_do_accounting/tests/common.py
@@ -89,6 +89,8 @@ class AccountInvoiceCommon(CommonSetup):
             'l10n_do_accounting.fiscal_type_purchase_credit_note')
         self.fiscal_type_dn = self.ref(
             'l10n_do_accounting.fiscal_type_debit_note')
+        self.fiscal_type_dn_purchase = self.ref(
+            'l10n_do_accounting.fiscal_type_purchase_debit_note')
 
         # Invoice lines
         account_id = self.env['account.account'].search(

--- a/l10n_do_accounting/tests/common.py
+++ b/l10n_do_accounting/tests/common.py
@@ -87,6 +87,8 @@ class AccountInvoiceCommon(CommonSetup):
             'l10n_do_accounting.fiscal_type_credit_note')
         self.fiscal_type_cn_purchase = self.ref(
             'l10n_do_accounting.fiscal_type_purchase_credit_note')
+        self.fiscal_type_dn = self.ref(
+            'l10n_do_accounting.fiscal_type_debit_note')
 
         # Invoice lines
         account_id = self.env['account.account'].search(

--- a/l10n_do_accounting/tests/common.py
+++ b/l10n_do_accounting/tests/common.py
@@ -85,6 +85,8 @@ class AccountInvoiceCommon(CommonSetup):
             'l10n_do_accounting.fiscal_type_informal')
         self.fiscal_type_cn = self.ref(
             'l10n_do_accounting.fiscal_type_credit_note')
+        self.fiscal_type_cn_purchase = self.ref(
+            'l10n_do_accounting.fiscal_type_purchase_credit_note')
 
         # Invoice lines
         account_id = self.env['account.account'].search(

--- a/l10n_do_accounting/tests/test_account_invoice.py
+++ b/l10n_do_accounting/tests/test_account_invoice.py
@@ -359,6 +359,74 @@ class AccountInvoiceTests(AccountInvoiceCommon):
         self.assertEqual(credit_note_id.origin_out, invoice_id.reference)
         self.assertEqual(credit_note_id.amount_total, 100)
 
+    def test_015_fiscal_vendor_refund_percentage(self):
+        """
+        Check fiscal vendor refunds (percentage) are created with all
+        correct data
+        """
+
+        invoice_id = self.invoice_obj.create({
+            'partner_id': self.partner_demo_1,
+            'fiscal_type_id': self.fiscal_type_informal,
+            'invoice_line_ids': self.invoice_line_data,
+            'type': 'in_invoice',
+        })
+        invoice_id.action_invoice_open()
+
+        refund_wizard_id = self.invoice_refund_obj.with_context(
+            {'active_ids': [invoice_id.id], 'active_id': invoice_id.id}
+        ).create({
+            'refund_type': 'percentage',
+            'filter_refund': 'refund',
+            'description': 'Discount',
+            'percentage': 10,
+        })
+        refund_wizard_id.invoice_refund()
+
+        credit_note_id = self.invoice_obj.search([
+            ('type', '=', 'in_refund')], limit=1)
+        credit_note_id.action_invoice_open()
+
+        self.assertEqual(credit_note_id.fiscal_type_id.id,
+                         self.fiscal_type_cn_purchase)
+        self.assertEqual(credit_note_id.origin_out, invoice_id.reference)
+        self.assertTrue(float_is_zero(
+            credit_note_id.amount_total - (invoice_id.amount_total * 0.1),
+            precision_digits=2))
+
+    def test_016_fiscal_vendor_refund_amount(self):
+        """
+        Check fiscal vendor refunds (amount) are created with all
+        correct data
+        """
+
+        invoice_id = self.invoice_obj.create({
+            'partner_id': self.partner_demo_1,
+            'fiscal_type_id': self.fiscal_type_informal,
+            'invoice_line_ids': self.invoice_line_data,
+            'type': 'in_invoice',
+        })
+        invoice_id.action_invoice_open()
+
+        refund_wizard_id = self.invoice_refund_obj.with_context(
+            {'active_ids': [invoice_id.id], 'active_id': invoice_id.id}
+        ).create({
+            'refund_type': 'fixed_amount',
+            'filter_refund': 'refund',
+            'description': 'Discount',
+            'amount': 100,
+        })
+        refund_wizard_id.invoice_refund()
+
+        credit_note_id = self.invoice_obj.search([
+            ('type', '=', 'in_refund')], limit=1)
+        credit_note_id.action_invoice_open()
+
+        self.assertEqual(credit_note_id.fiscal_type_id.id,
+                         self.fiscal_type_cn_purchase)
+        self.assertEqual(credit_note_id.origin_out, invoice_id.reference)
+        self.assertEqual(credit_note_id.amount_total, 100)
+
 # Account Invoice Tests
 
 # TODO: fiscal vendor refunds are created with all correct data

--- a/l10n_do_accounting/tests/test_account_invoice.py
+++ b/l10n_do_accounting/tests/test_account_invoice.py
@@ -467,7 +467,7 @@ class AccountInvoiceTests(AccountInvoiceCommon):
             debit_note_id.amount_total - (invoice_id.amount_total * 0.1),
             precision_digits=2))
 
-    def test_018_fiscal_customer_debit_note_percentage(self):
+    def test_018_fiscal_customer_debit_note_amount(self):
         """
         Check fiscal customer debit notes (amount) are created with all
         correct data
@@ -505,6 +505,78 @@ class AccountInvoiceTests(AccountInvoiceCommon):
         self.assertEqual(debit_note_id.origin_out, invoice_id.reference)
         self.assertEqual(debit_note_id.amount_total, 100)
 
-# Account Invoice Tests
+    def test_019_fiscal_vendor_debit_note_percentage(self):
+        """
+        Check fiscal vendor debit notes (percentage) are created with all
+        correct data
+        """
 
-# TODO: fiscal vendor debit notes are created with all correct data
+        invoice_id = self.invoice_obj.create({
+            'partner_id': self.partner_demo_1,
+            'fiscal_type_id': self.fiscal_type_informal,
+            'invoice_line_ids': self.invoice_line_data,
+            'type': 'in_invoice',
+        })
+        invoice_id.action_invoice_open()
+
+        refund_wizard_id = self.invoice_refund_obj.with_context(
+            {'active_ids': [invoice_id.id], 'active_id': invoice_id.id,
+             'debit_note': 'in_debit'}
+        ).create({
+            'refund_type': 'percentage',
+            'filter_refund': 'refund',
+            'description': 'Discount',
+            'percentage': 10,
+        })
+        refund_wizard_id.invoice_debit_note()
+
+        debit_note_id = self.invoice_obj.search([
+            ('type', '=', 'in_invoice'),
+            ('is_debit_note', '=', True),
+        ], limit=1)
+        debit_note_id.action_invoice_open()
+
+        self.assertEqual(debit_note_id.fiscal_type_id.id,
+                         self.fiscal_type_dn_purchase)
+        self.assertEqual(debit_note_id.origin_out, invoice_id.reference)
+        self.assertTrue(float_is_zero(
+            debit_note_id.amount_total - (invoice_id.amount_total * 0.1),
+            precision_digits=2))
+
+    def test_020_fiscal_customer_debit_note_amount(self):
+        """
+        Check fiscal vendor debit notes (amount) are created with all
+        correct data
+        """
+
+        invoice_id = self.invoice_obj.create({
+            'partner_id': self.partner_demo_1,
+            'fiscal_type_id': self.fiscal_type_informal,
+            'invoice_line_ids': self.invoice_line_data,
+            'type': 'in_invoice',
+        })
+        invoice_id.action_invoice_open()
+
+        refund_wizard_id = self.invoice_refund_obj.with_context(
+            {'active_ids': [invoice_id.id], 'active_id': invoice_id.id,
+             'debit_note': 'in_debit'}
+        ).create({
+            'refund_type': 'fixed_amount',
+            'filter_refund': 'refund',
+            'description': 'Discount',
+            'amount': 100,
+        })
+        refund_wizard_id.invoice_debit_note()
+
+        debit_note_id = self.invoice_obj.search([
+            ('type', '=', 'in_invoice'),
+            ('is_debit_note', '=', True),
+        ], limit=1)
+        debit_note_id.action_invoice_open()
+
+        dn_type = self.fiscal_type_obj.browse(self.fiscal_type_dn_purchase)
+
+        self.assertEqual(debit_note_id.fiscal_type_id.id,
+                         self.fiscal_type_dn_purchase)
+        self.assertEqual(debit_note_id.origin_out, invoice_id.reference)
+        self.assertEqual(debit_note_id.amount_total, 100)

--- a/l10n_do_accounting/tests/test_account_invoice.py
+++ b/l10n_do_accounting/tests/test_account_invoice.py
@@ -429,8 +429,6 @@ class AccountInvoiceTests(AccountInvoiceCommon):
 
 # Account Invoice Tests
 
-# TODO: fiscal vendor refunds are created with all correct data
-
 # TODO: fiscal customer debit notes are created with all correct data
 
 # TODO: fiscal vendor debit notes are created with all correct data

--- a/l10n_do_accounting/tests/test_account_invoice.py
+++ b/l10n_do_accounting/tests/test_account_invoice.py
@@ -4,7 +4,7 @@ from datetime import timedelta as td
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tools import pycompat, float_is_zero
+from odoo.tools import float_is_zero
 from .common import AccountInvoiceCommon, environment
 
 

--- a/l10n_do_accounting/tests/test_account_invoice.py
+++ b/l10n_do_accounting/tests/test_account_invoice.py
@@ -574,8 +574,6 @@ class AccountInvoiceTests(AccountInvoiceCommon):
         ], limit=1)
         debit_note_id.action_invoice_open()
 
-        dn_type = self.fiscal_type_obj.browse(self.fiscal_type_dn_purchase)
-
         self.assertEqual(debit_note_id.fiscal_type_id.id,
                          self.fiscal_type_dn_purchase)
         self.assertEqual(debit_note_id.origin_out, invoice_id.reference)

--- a/l10n_do_accounting/tests/test_account_invoice.py
+++ b/l10n_do_accounting/tests/test_account_invoice.py
@@ -427,8 +427,84 @@ class AccountInvoiceTests(AccountInvoiceCommon):
         self.assertEqual(credit_note_id.origin_out, invoice_id.reference)
         self.assertEqual(credit_note_id.amount_total, 100)
 
-# Account Invoice Tests
+    def test_017_fiscal_customer_debit_note_percentage(self):
+        """
+        Check fiscal customer debit notes (percentage) are created with all
+        correct data
+        """
 
-# TODO: fiscal customer debit notes are created with all correct data
+        invoice_id = self.invoice_obj.create({
+            'partner_id': self.partner_demo_1,
+            'fiscal_type_id': self.fiscal_type_fiscal,
+            'invoice_line_ids': self.invoice_line_data,
+        })
+        invoice_id.action_invoice_open()
+
+        refund_wizard_id = self.invoice_refund_obj.with_context(
+            {'active_ids': [invoice_id.id], 'active_id': invoice_id.id,
+             'debit_note': 'out_debit'}
+        ).create({
+            'refund_type': 'percentage',
+            'filter_refund': 'refund',
+            'description': 'Discount',
+            'percentage': 10,
+        })
+        refund_wizard_id.invoice_debit_note()
+
+        debit_note_id = self.invoice_obj.search([
+            ('type', '=', 'out_invoice'),
+            ('is_debit_note', '=', True),
+        ], limit=1)
+        debit_note_id.action_invoice_open()
+
+        dn_type = self.fiscal_type_obj.browse(self.fiscal_type_dn)
+
+        self.assertEqual(debit_note_id.fiscal_type_id.id,
+                         self.fiscal_type_dn)
+        self.assertEqual(str(debit_note_id.reference)[:3], dn_type.prefix)
+        self.assertEqual(debit_note_id.origin_out, invoice_id.reference)
+        self.assertTrue(float_is_zero(
+            debit_note_id.amount_total - (invoice_id.amount_total * 0.1),
+            precision_digits=2))
+
+    def test_018_fiscal_customer_debit_note_percentage(self):
+        """
+        Check fiscal customer debit notes (amount) are created with all
+        correct data
+        """
+
+        invoice_id = self.invoice_obj.create({
+            'partner_id': self.partner_demo_1,
+            'fiscal_type_id': self.fiscal_type_fiscal,
+            'invoice_line_ids': self.invoice_line_data,
+        })
+        invoice_id.action_invoice_open()
+
+        refund_wizard_id = self.invoice_refund_obj.with_context(
+            {'active_ids': [invoice_id.id], 'active_id': invoice_id.id,
+             'debit_note': 'out_debit'}
+        ).create({
+            'refund_type': 'fixed_amount',
+            'filter_refund': 'refund',
+            'description': 'Discount',
+            'amount': 100,
+        })
+        refund_wizard_id.invoice_debit_note()
+
+        debit_note_id = self.invoice_obj.search([
+            ('type', '=', 'out_invoice'),
+            ('is_debit_note', '=', True),
+        ], limit=1)
+        debit_note_id.action_invoice_open()
+
+        dn_type = self.fiscal_type_obj.browse(self.fiscal_type_dn)
+
+        self.assertEqual(debit_note_id.fiscal_type_id.id,
+                         self.fiscal_type_dn)
+        self.assertEqual(str(debit_note_id.reference)[:3], dn_type.prefix)
+        self.assertEqual(debit_note_id.origin_out, invoice_id.reference)
+        self.assertEqual(debit_note_id.amount_total, 100)
+
+# Account Invoice Tests
 
 # TODO: fiscal vendor debit notes are created with all correct data


### PR DESCRIPTION
- [IMP] l10n_do_accounting: added percetage fiscal refund tests
- [REF] l10n_do_accounting: remove unnused package
- [IMP] l10n_do_accounting: added fixed_amount fiscal refund tests
- [FIX] l10n_do_accounting: do not ask for fiscal sequence if puchase a… …
- [IMP] l10n_do_accounting: added fiscal vendor credit notes amount and… …
- [REF] l10n_do_accounting: removed TODO note
- [IMP] l10n_do_accounting: added customer debit notes percentage/fixed… …
- [IMP] l10n_do_accounting: added vendor debit notes percentage/fixed a… …