### PR TITLE
[IMP] dgii_reports: Adding a url widget to build a custom url for reports

### DIFF
--- a/dgii_reports/controllers/dgii_reports_controllers.py
+++ b/dgii_reports/controllers/dgii_reports_controllers.py
@@ -7,7 +7,7 @@ from odoo.http import request, Controller, route
 
 class DgiiReportsControllers(Controller):
 
-    @route(['/<ncf_rnc>'], type='http', auth='user')
+    @route(['/dgii_reports/<ncf_rnc>'], type='http', auth='user')
     def redirect_link(self, ncf_rnc):
 
         env = request.env

--- a/dgii_reports/static/src/js/widget.js
+++ b/dgii_reports/static/src/js/widget.js
@@ -1,0 +1,21 @@
+odoo.define('dgii_report.dgii_report_widget', function (require) {
+    "use strict";
+
+    var field_registry = require('web.field_registry');
+    var UrlChar = field_registry.get('url');
+
+    var UrlDgiiReportsWidget = UrlChar.extend({
+        init: function () {
+            this._super.apply(this, arguments);
+	    
+	    this.value = "dgii_reports/" + this.value;
+        },
+    });
+
+    field_registry.add('dgii_reports_url', UrlDgiiReportsWidget);
+
+    return {
+        UrlDgiiReportsWidget: UrlDgiiReportsWidget,
+    };
+
+});

--- a/dgii_reports/static/src/js/widget.js
+++ b/dgii_reports/static/src/js/widget.js
@@ -5,10 +5,11 @@ odoo.define('dgii_report.dgii_report_widget', function (require) {
     var UrlChar = field_registry.get('url');
 
     var UrlDgiiReportsWidget = UrlChar.extend({
-        init: function () {
-            this._super.apply(this, arguments);
-	    
-	    this.value = "dgii_reports/" + this.value;
+	_renderReadonly: function () {
+            this.$el.text(this.attrs.text || this.value)
+                .addClass('o_form_uri o_text_overflow')
+                .attr('target', '_blank')
+                .attr('href', "dgii_reports/"+this.value);
         },
     });
 

--- a/dgii_reports/views/dgii_report_templates.xml
+++ b/dgii_reports/views/dgii_report_templates.xml
@@ -5,6 +5,7 @@
         <xpath expr="." position="inside">
             <link rel="stylesheet" type="text/css"
                   href='/dgii_reports/static/src/less/dgii_reports.css'/>
+	    <script src="dgii_reports/static/src/js/widget.js" type="text/javascript"></script>
         </xpath>
     </template>
 


### PR DESCRIPTION
Con este widget, las url tendran **"dgii_reports/"** delante para evitar colisión con otros módulos de website.

Antes:
- midominio.com/<valor_campo_con_widget_url>

Ahora:
- midominio.com/**dgii_reports/**<valor_campo_con_nuevo_widget_url>