### PR TITLE
better imp avoining singleton error

### DIFF
--- a/ncf_pos/models/pos_order.py
+++ b/ncf_pos/models/pos_order.py
@@ -322,9 +322,10 @@ class PosOrder(models.Model):
                 out_refund_invoice = self.env["account.invoice"].sudo().search(
                     [('reference', '=', payment_name)])
                 if out_refund_invoice:
-                    move_line_ids = out_refund_invoice.move_id.line_ids
-                    move_line_ids = move_line_ids.filtered(
-                        lambda r: not r.reconciled and r.account_id.
+                    move_line_ids = out_refund_invoice.mapped(
+                        'move_id.line_ids'
+                        ).filtered(
+                            lambda r: not r.reconciled and r.account_id.
                         internal_type == 'receivable' and r.partner_id == self.
                         partner_id.commercial_partner_id)
                     for move_line_id in move_line_ids:


### PR DESCRIPTION
Fixes: 

pos_order.py", line 120, in _process_order
    order.add_payment(self._payment_fields(payments[2]))
  File "/odoo/odoo-server/src/custom/iterativo/l10n-dominicana/ncf_pos/models/pos_order.py", line 325, in add_payment
    move_line_ids = out_refund_invoice.move_id.line_ids
  File "/odoo/odoo-server/src/odoo/odoo/fields.py", line 947, in _get_
    record.ensure_one()
  File "/odoo/odoo-server/src/odoo/odoo/models.py", line 4428, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.invoice(83648, 82123)