### PR TITLE
[ADD] Turn off/on DGII validation on Purchase

### DIFF
--- a/l10n_do_accounting/models/account_invoice.py
+++ b/l10n_do_accounting/models/account_invoice.py
@@ -493,7 +493,10 @@ class AccountInvoice(models.Model):
                     )
 
                 # TODO move this to l10n_do_external_validation_ncf
-                elif not ncf_validation.check_dgii(self.partner_id.vat, ncf):
+                elif (
+                    self.journal_id.l10n_do_ncf_remote_validation 
+                    and not ncf_validation.check_dgii(self.partner_id.vat, ncf)
+                    ):
                     raise ValidationError(
                         _(
                             "NCF rejected by DGII\n\n"

--- a/l10n_do_accounting/models/account_invoice.py
+++ b/l10n_do_accounting/models/account_invoice.py
@@ -496,7 +496,7 @@ class AccountInvoice(models.Model):
                 elif (
                     self.journal_id.l10n_do_ncf_remote_validation 
                     and not ncf_validation.check_dgii(self.partner_id.vat, ncf)
-                    ):
+                ):
                     raise ValidationError(
                         _(
                             "NCF rejected by DGII\n\n"

--- a/l10n_do_accounting/models/account_invoice.py
+++ b/l10n_do_accounting/models/account_invoice.py
@@ -494,7 +494,7 @@ class AccountInvoice(models.Model):
 
                 # TODO move this to l10n_do_external_validation_ncf
                 elif (
-                    self.journal_id.l10n_do_ncf_remote_validation 
+                    self.journal_id.l10n_do_ncf_remote_validation
                     and not ncf_validation.check_dgii(self.partner_id.vat, ncf)
                 ):
                     raise ValidationError(

--- a/l10n_do_accounting/models/account_journal.py
+++ b/l10n_do_accounting/models/account_journal.py
@@ -6,6 +6,7 @@ class AccountJournal(models.Model):
     _inherit = "account.journal"
 
     l10n_do_fiscal_journal = fields.Boolean(string="Fiscal Journal")
+    l10n_do_ncf_remote_validation = fields.Boolean(string="Validate With DGII", default = False)
 
     payment_form = fields.Selection(
         [

--- a/l10n_do_accounting/models/account_journal.py
+++ b/l10n_do_accounting/models/account_journal.py
@@ -6,7 +6,9 @@ class AccountJournal(models.Model):
     _inherit = "account.journal"
 
     l10n_do_fiscal_journal = fields.Boolean(string="Fiscal Journal")
-    l10n_do_ncf_remote_validation = fields.Boolean(string="Validate With DGII", default = False)
+    l10n_do_ncf_remote_validation = fields.Boolean(
+        string="Validate With DGII", 
+        default = False)
 
     payment_form = fields.Selection(
         [

--- a/l10n_do_accounting/models/account_journal.py
+++ b/l10n_do_accounting/models/account_journal.py
@@ -7,9 +7,8 @@ class AccountJournal(models.Model):
 
     l10n_do_fiscal_journal = fields.Boolean(string="Fiscal Journal")
     l10n_do_ncf_remote_validation = fields.Boolean(
-        string="Validate With DGII", 
-        default = False)
-
+        string="Validate With DGII",
+        default=False)
     payment_form = fields.Selection(
         [
             ("cash", "Cash"),

--- a/l10n_do_accounting/views/account_journal_views.xml
+++ b/l10n_do_accounting/views/account_journal_views.xml
@@ -14,6 +14,9 @@
                 <field name="payment_form"
                        attrs="{'invisible':[('type', 'in', ('sale','purchase','general'))]}"/>
 
+                <field name="l10n_do_ncf_remote_validation"
+                       attrs="{'invisible':[('l10n_do_fiscal_journal','=',False),('type','!=','purchase')]}"/>
+
             </xpath>
 
         </field>

--- a/l10n_do_accounting/wizard/account_invoice_refund.py
+++ b/l10n_do_accounting/wizard/account_invoice_refund.py
@@ -274,9 +274,11 @@ class AccountInvoiceRefund(models.TransientModel):
                     )
 
                 # TODO move this to l10n_do_external_validation_ncf
-                elif not ncf_validation.check_dgii(
-                    invoice.partner_id.vat, self.refund_reference
-                ):
+                elif (
+                    invoice.journal_id.l10n_do_ncf_remote_validation
+                    and not ncf_validation.check_dgii(
+                    invoice.partner_id.vat, self.refund_reference)
+                    ):
                     raise ValidationError(
                         _(
                             "NCF rejected by DGII\n\n"

--- a/l10n_do_accounting/wizard/account_invoice_refund.py
+++ b/l10n_do_accounting/wizard/account_invoice_refund.py
@@ -277,7 +277,8 @@ class AccountInvoiceRefund(models.TransientModel):
                 elif (
                     invoice.journal_id.l10n_do_ncf_remote_validation
                     and not ncf_validation.check_dgii(
-                    invoice.partner_id.vat, self.refund_reference)
+                        invoice.partner_id.vat, self.refund_reference
+                    )
                     ):
                     raise ValidationError(
                         _(

--- a/l10n_do_accounting/wizard/account_invoice_refund.py
+++ b/l10n_do_accounting/wizard/account_invoice_refund.py
@@ -276,10 +276,8 @@ class AccountInvoiceRefund(models.TransientModel):
                 # TODO move this to l10n_do_external_validation_ncf
                 elif (
                     invoice.journal_id.l10n_do_ncf_remote_validation
-                    and not ncf_validation.check_dgii(
-                        invoice.partner_id.vat, self.refund_reference
-                    )
-                    ):
+                    and not ncf_validation.check_dgii(invoice.partner_id.vat, self.refund_reference)
+                ):
                     raise ValidationError(
                         _(
                             "NCF rejected by DGII\n\n"


### PR DESCRIPTION
With this we can turn off/on validation of ncf on Purchase Journal if DGII is offline we can turn off, 

But I think later on we should check if stdnum or other server is online/offline and then raise an alert and mark the NCF as **"not validated with DGII"** but create a button of I don't know now to validate is the server is online again. It's just guessing... 

But right now it's alternative.