### PR TITLE
11.0 Fixes the following

### DIFF
--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -45,7 +45,8 @@ class AccountInvoice(models.Model):
     @api.depends('journal_id', 'sale_fiscal_type')
     def _compute_sequence_almost_depleted(self):
         for invoice in self:
-            if invoice.journal_id.ncf_control and invoice.type == "out_invoice":
+            if invoice.journal_id.ncf_control and invoice.type == "out_invoice" and \
+               invoice.sale_fiscal_type:
                 sequence = invoice.journal_id.date_range_ids.filtered(
                     lambda seq: seq.sale_fiscal_type == invoice.
                     sale_fiscal_type)
@@ -57,7 +58,8 @@ class AccountInvoice(models.Model):
 
             if invoice.journal_id.purchase_type in (
                     'informal', 'minor',
-                    'exterior') and invoice.type == "in_invoice":
+                    'exterior') and invoice.type == "in_invoice" and \
+                    invoice.journal.purchase_type:
                 sequence = invoice.journal_id.date_range_ids.filtered(
                     lambda seq: seq.sale_fiscal_type == invoice.journal_id.
                     purchase_type)

--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -367,7 +367,7 @@ class AccountInvoice(models.Model):
     @api.multi
     def action_invoice_open(self):
         for inv in self:
-            if inv.amount_untaxed == 0:
+            if inv.amount_total == 0:
                 raise UserError(_(
                     u"No se puede validar una factura cuyo monto total sea"
                     " igual a 0."))

--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -215,7 +215,7 @@ class AccountInvoice(models.Model):
                     u"para registrar compras Fiscales")
                     .format(self.partner_id.name))
 
-            elif (self.journal_id.ncf_remote_validation and len(NCF) == '9' and 
+            elif (self.journal_id.ncf_remote_validation and len(NCF) == '9' and
                   not ncf_validation.check_dgii(self.partner_id.vat, NCF)):
                 raise ValidationError(_(
                     u"NCF NO pasó validación en DGII\n\n"


### PR DESCRIPTION
[IMP] ncf_manager: Avoid orders with discounts to hang on pos
[REF] ncf_manager: flake8 fix
[FIX] ncf_manager: singleton error when customer invoice doesn't have sale_fiscal_type or supplier invoice's journal doesn't have purchase_type. Traceback:
`_compute_sequence_almost_depleted
    if sequence.number_next_actual >= sequence.warning_ncf:
  File "/odoo/odoo-server/src/odoo/odoo/fields.py", line 1003, in __get__
    record.ensure_one()
  File "/odoo/odoo-server/src/odoo/odoo/models.py", line 4744, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: ir.sequence.date_range(65, 68, 139)`

These affects v12 as well