### PR TITLE
[IMP] ncf_invoice_template: tax sum readability

### DIFF
--- a/ncf_invoice_template/report/report_invoice.xml
+++ b/ncf_invoice_template/report/report_invoice.xml
@@ -252,6 +252,7 @@
                 </span>
             </t>
         </xpath>
+        <xpath expr="/t/t/div/div[3]/div[1]/div/table/t/tr/t[2]/td[1]/span[2]" position="replace"/>
 
         <xpath expr="//div[@id='total']" position="after">
             <div class="text-muted text-right">


### PR DESCRIPTION
Removed "on x amount" label from the invoice tax summary to avoid confusion when dealing with multiple tax groups. 

![image](https://user-images.githubusercontent.com/28060986/79731571-723aa880-82c0-11ea-9674-41896045e798.png)

     **------------- VS -------------**

![image](https://user-images.githubusercontent.com/28060986/79731477-520ae980-82c0-11ea-806b-152b46178692.png)

**Applies only to V12.0**