### PR TITLE
[IMP] ncf_invoice_template: tax sum readability

### DIFF
--- a/l10n_do_accounting/views/report_invoice.xml
+++ b/l10n_do_accounting/views/report_invoice.xml
@@ -229,6 +229,7 @@
                 </span>
             </t>
         </xpath>
+        <xpath expr="/t/t/div/div[3]/div[1]/div/table/t[1]/tr/t[2]/td[1]/span[2]" position="replace"/>
         <xpath expr="//div[@id='total']" position="after">
             <div class="text-muted text-right">
                 <span>


### PR DESCRIPTION
Removed "on x amount" label from the invoice tax summary to avoid confusion when dealing with multiple tax groups. 

![image](https://user-images.githubusercontent.com/28060986/79733948-e88cda00-82c3-11ea-8d2a-879ab8b5c8ee.png)
                 
       **------------------ VS ------------------**

![image](https://user-images.githubusercontent.com/28060986/79733986-fb9faa00-82c3-11ea-830a-a6753e1b8ed1.png)

**Applies only to V13.0**