### PR TITLE
[FIX] ncf_manager: removing the optional external dependency

### DIFF
--- a/ncf_manager/__manifest__.py
+++ b/ncf_manager/__manifest__.py
@@ -39,7 +39,7 @@
     },
 
     # any module necessary for this one to work correctly
-    'depends': ['account', 'l10n_do', 'account_cancel', 'l10n_do_rnc_validation'],
+    'depends': ['account', 'l10n_do', 'account_cancel'],
 
     'data': [
         'data/ir_config_parameters.xml',

--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -463,7 +463,8 @@ class AccountInvoice(models.Model):
         if self._context.get("credit_note_supplier_ncf", False):
             res.update({
                 "reference": self._context["credit_note_supplier_ncf"],
-                "origin_out": self.reference
+                "origin_out": self.reference,
+                "expense_type": self.expense_type
             })
         return res
 


### PR DESCRIPTION
Tal como acordamos en Instagram.  Realice las pruebas y con tan solo remover el módulo l10n_do_rnc_validation del __manifest__.py funciona todo normalmente.  Puedo buscar RNC tanto por el número como por el nombre.   

Instalar el modulo l10n_do_rnc_validation sería opcional para mejorar la disponibilidad de la consulta de los RNC cuando el DGII realice cambios o no este disponible.   