### PR TITLE
[FIX] ncf_manager: adding expense_type value for Credit Note

### DIFF
--- a/ncf_manager/models/account_invoice.py
+++ b/ncf_manager/models/account_invoice.py
@@ -463,7 +463,8 @@ class AccountInvoice(models.Model):
         if self._context.get("credit_note_supplier_ncf", False):
             res.update({
                 "reference": self._context["credit_note_supplier_ncf"],
-                "origin_out": self.reference
+                "origin_out": self.reference,
+                "expense_type": self.expense_type
             })
         return res
 


### PR DESCRIPTION
Al crear una Nota de Crédito, por defecto no tomaba el valor correspondiente para el **Tipo de Costos y Gastos** lo cual podía ser una limitante que bloqueaba al usuario de poder editar una factura en algunos casos como si la factura se creaba y validaba automáticamente al cancelar y conciliar o desde un borrador que el usuario olvidaba seleccionar el Tipo de Costos y Gastos correspondiente.

Por defecto a nivel contable el Tipo de Costos y Gastos correcto es el de la factura original.