### PR TITLE
[FIX] Updating due date ncf on POS Ticket

### DIFF
--- a/ncf_pos/static/src/xml/ncf_ticket.xml
+++ b/ncf_pos/static/src/xml/ncf_ticket.xml
@@ -48,7 +48,7 @@
                     </t>
                     <t t-if="sale_fiscal_type_client.ticket_label !== 'Consumo'">
                         <br/>
-                        <strong>Válida hasta: 31/12/2019</strong>
+                        <strong>Válida hasta: 31/12/2020</strong>
                     </t>
                 </div>
             </div>


### PR DESCRIPTION
En lo que se resuelve el caso.

Cuando se escribió este código todos los comprobantes vencían en la misma fecha. Ahora es muy probable que la gran mayoría de comprobantes venzan en 2020 o 2021.