### PR TITLE
[FIX] ncf_manager: IntegrityError

### DIFF
--- a/ncf_manager/data/ir_config_parameters.xml
+++ b/ncf_manager/data/ir_config_parameters.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo noupdate="1">
-    <record id="query_dgii_parameter" model="ir.config_parameter">
+    <record id="query_dgii_parameter" model="ir.config_parameter" forcecreate="0">
         <field name="key">dgii.wsmovil</field>
         <field name="value">True</field>
     </record>


### PR DESCRIPTION
duplicate key value violates unique constraint "ir_config_parameter_key_uniq" DETAIL: Key (key)=(dgii.wsmovil) already exists.