### PR TITLE
[13.0][FIX] l10n_do_accounting: l10n_latam_document_number visible when it should not

### DIFF
--- a/l10n_do_accounting/i18n/es_DO.po
+++ b/l10n_do_accounting/i18n/es_DO.po
@@ -6,21 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-08 20:47+0000\n"
-"PO-Revision-Date: 2020-12-08 20:47+0000\n"
+"POT-Creation-Date: 2020-12-10 18:26+0000\n"
+"PO-Revision-Date: 2020-12-10 18:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: l10n_do_accounting
-#. openerp-web
-#: code:addons/l10n_do_accounting/static/src/xml/fiscal_sequence_warning_template.xml:0
-#, python-format
-msgid "- Remains:"
-msgstr "- Restante:"
 
 #. module: l10n_do_accounting
 #: code:addons/l10n_do_accounting/models/account_move.py:0
@@ -487,13 +480,6 @@ msgid "DGII"
 msgstr ""
 
 #. module: l10n_do_accounting
-#. openerp-web
-#: code:addons/l10n_do_accounting/static/src/js/fiscal_sequence_warning.js:0
-#, python-format
-msgid "Dashboard"
-msgstr "Tablero"
-
-#. module: l10n_do_accounting
 #: model:ir.model.fields,field_description:l10n_do_accounting.field_res_company__l10n_do_default_client
 msgid "Default Customer"
 msgstr "Cliente predeterminado"
@@ -564,21 +550,6 @@ msgstr "Reembolso completo"
 #, python-format
 msgid "Go to Companies"
 msgstr "Ir a Compañías"
-
-#. module: l10n_do_accounting
-#. openerp-web
-#: code:addons/l10n_do_accounting/static/src/xml/fiscal_sequence_warning_template.xml:0
-#, python-format
-msgid "Go to Fiscal Sequences"
-msgstr "Ir a Secuencias Fiscales"
-
-#. module: l10n_do_accounting
-#: code:addons/l10n_do_accounting/models/account_move.py:0
-#, python-format
-msgid "Goods sales to overseas customers must have Exportaciones Fiscal Type"
-msgstr ""
-"La venta de bienes a clientes en el exterior deben ser emitidas con Tipo "
-"Fiscal *Exportaciones*"
 
 #. module: l10n_do_accounting
 #: code:addons/l10n_do_accounting/models/res_partner.py:0
@@ -662,6 +633,11 @@ msgid "Is e-CF issuer"
 msgstr "Es Emisor Electrónico"
 
 #. module: l10n_do_accounting
+#: model:ir.model.fields,field_description:l10n_do_accounting.field_account_move__is_l10n_do_internal_sequence
+msgid "Is internal sequence"
+msgstr "Es secuencia interna"
+
+#. module: l10n_do_accounting
 #: model:ir.model,name:l10n_do_accounting.model_account_journal
 msgid "Journal"
 msgstr "Diario"
@@ -700,18 +676,6 @@ msgstr "Tipo de Comprobante"
 #: model:ir.model.fields,field_description:l10n_do_accounting.field_account_move__l10n_do_origin_ncf
 msgid "Modifies"
 msgstr "Afecta a"
-
-#. module: l10n_do_accounting
-#: code:addons/l10n_do_accounting/models/account_move.py:0
-#, python-format
-msgid ""
-"NCF *{}* does not correspond with the fiscal type\n"
-"\n"
-"You cannot register Consumo NCF (02/32) for purchases"
-msgstr ""
-"El NCF *{}* no se corresponde con el tipo fiscal\n"
-"\n"
-"No puede registrar NCF de Consumo (02 / 32) para compras"
 
 #. module: l10n_do_accounting
 #: model:ir.model.fields,field_description:l10n_do_accounting.field_res_company__l10n_do_ncf_exp_date
@@ -858,14 +822,6 @@ msgid "Sequences"
 msgstr "Secuencias"
 
 #. module: l10n_do_accounting
-#: code:addons/l10n_do_accounting/models/account_move.py:0
-#, python-format
-msgid "Services sales to overseas customer must have Consumo Fiscal Type"
-msgstr ""
-"La venta de servicios a clientes en el exterior deben ser con comprobante de"
-" Consumo"
-
-#. module: l10n_do_accounting
 #: model:ir.model.fields.selection,name:l10n_do_accounting.selection__l10n_latam_document_type__internal_type__in_credit_note
 msgid "Supplier Credit Note"
 msgstr "Nota de Crédito de Proveedor"
@@ -963,30 +919,6 @@ msgid "You cannot create Credit Notes from multiple documents at a time."
 msgstr "No puede crear Notas de Crédito desde múltiples documentos a la vez."
 
 #. module: l10n_do_accounting
-#: code:addons/l10n_do_accounting/models/account_move.py:0
-#, python-format
-msgid "You cannot validate an invoice with a total amount equals to 0."
-msgstr "No puede validar una factura con un monto total igual a 0."
-
-#. module: l10n_do_accounting
-#: code:addons/l10n_do_accounting/models/account_move.py:0
-#, python-format
-msgid ""
-"You cannot validate and invoice of Fiscal Type Regímen Especial with ITBIS/ISC.\n"
-"\n"
-"See DGII General Norm 05-19, Art. 3 for further information"
-msgstr ""
-"No puede validar una factura de Régimen Especial con ITBIS/ISC.\n"
-"\n"
-"Vea la Norma General 05-19, Art. 3 para más información"
-
-#. module: l10n_do_accounting
-#: code:addons/l10n_do_accounting/models/account_move.py:0
-#, python-format
-msgid "You must withhold 100% of ITBIS"
-msgstr "Debe retener el 100% del ITBIS"
-
-#. module: l10n_do_accounting
 #: model_terms:ir.ui.view,arch_db:l10n_do_accounting.view_account_move_reversal_inherited
 msgid ""
 "You will be able to edit and validate this\n"
@@ -1021,10 +953,3 @@ msgstr ""
 #, python-format
 msgid "special from Tax Paying"
 msgstr "Exento"
-
-#. module: l10n_do_accounting
-#. openerp-web
-#: code:addons/l10n_do_accounting/static/src/xml/fiscal_sequence_warning_template.xml:0
-#, python-format
-msgid "¡NCF almost deplete!"
-msgstr "¡NCF casi agotado!"

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -101,6 +101,22 @@ class AccountMove(models.Model):
         string="Company in contingency",
         compute="_compute_company_in_contingency",
     )
+    is_l10n_do_internal_sequence = fields.Boolean(
+        string="Is internal sequence", compute="_compute_is_l10n_do_internal_sequence"
+    )
+
+    @api.depends("type", "l10n_latam_document_type_id.l10n_do_ncf_type")
+    def _compute_is_l10n_do_internal_sequence(self):
+        for invoice in self:
+            invoice.is_l10n_do_internal_sequence = invoice.type in (
+                "out_invoice",
+                "out_refund",
+            ) or invoice.l10n_latam_document_type_id.l10n_do_ncf_type in (
+                "minor",
+                "e-minor",
+                "informal",
+                "e-informal",
+            )
 
     @api.depends("company_id", "company_id.l10n_do_ecf_issuer")
     def _compute_company_in_contingency(self):

--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -10,6 +10,7 @@
                 <field name="is_ecf_invoice" invisible="1"/>
                 <field name="l10n_latam_country_code" invisible="1"/>
                 <field name="l10n_do_company_in_contingency" invisible="1"/>
+                <field name="is_l10n_do_internal_sequence" invisible="1"/>
             </field>
             <xpath expr="//field[@name='tax_lock_date_message']/.." position="after">
                 <div class="alert alert-warning"
@@ -54,7 +55,7 @@
             </xpath>
             <xpath expr="//field[@name='l10n_latam_document_number']" position="attributes">
                 <attribute name="attrs">{
-                    'invisible': ['|', ('l10n_latam_use_documents', '=', False), '&amp;', ('type', 'in', ('out_invoice', 'out_refund')), ('state', '=', 'draft')],
+                    'invisible': ['|', ('l10n_latam_use_documents', '=', False), '|', '&amp;', ('is_l10n_do_internal_sequence', '=', True), ('state', '=', 'draft'), '&amp;', ('type', 'in', ('out_invoice', 'out_refund')), ('state', '=', 'draft')],
                     'required': [('l10n_latam_sequence_id', '=', False), ('l10n_latam_use_documents', '=', True)],
                     'readonly': [('state', '!=', 'draft')]}
                 </attribute>

--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -55,7 +55,10 @@
             </xpath>
             <xpath expr="//field[@name='l10n_latam_document_number']" position="attributes">
                 <attribute name="attrs">{
-                    'invisible': ['|', ('l10n_latam_use_documents', '=', False), '|', '&amp;', ('is_l10n_do_internal_sequence', '=', True), ('state', '=', 'draft'), '&amp;', ('type', 'in', ('out_invoice', 'out_refund')), ('state', '=', 'draft')],
+                    'invisible': [
+                    '|', '&amp;', ('l10n_latam_use_documents', '=', False), ('l10n_latam_country_code', '=', 'DO'),
+                    '|', '&amp;', ('is_l10n_do_internal_sequence', '=', True), ('state', '=', 'draft'),
+                    '&amp;', ('type', 'in', ('out_invoice', 'out_refund')), '&amp;', ('state', '=', 'draft'), ('l10n_latam_country_code', '=', 'DO')],
                     'required': [('l10n_latam_sequence_id', '=', False), ('l10n_latam_use_documents', '=', True)],
                     'readonly': [('state', '!=', 'draft')]}
                 </attribute>


### PR DESCRIPTION
- Added new computed boolean field which indicates if NCF sequence is internally generated. This field is going to be used on external modules
- Fixed l10n_latam_document_number view visibility using the new boolean field.