### PR TITLE
[IMP] l10n_do_accounting: ECF field improvements

### DIFF
--- a/l10n_do_accounting/models/account_journal.py
+++ b/l10n_do_accounting/models/account_journal.py
@@ -27,13 +27,18 @@ class AccountJournal(models.Model):
         string="Sequences",
     )
 
-    def _get_all_ncf_types(self, types_list):
+    def _get_all_ncf_types(self, types_list, invoice):
         """
         Include ECF type prefixes if company is ECF issuer
         :param types_list: NCF list used to create fiscal sequences
         :return: types_list
         """
-        if self.company_id.l10n_do_ecf_issuer:
+
+        if self.company_id.l10n_do_ecf_issuer or (
+            not self.company_id.l10n_do_ecf_issuer
+            and invoice.partner_id.l10n_do_dgii_tax_payer_type
+            and invoice.partner_id.l10n_do_dgii_tax_payer_type != "non_payer"
+        ):
             types_list.extend(
                 ["e-%s" % d for d in types_list if d not in ("unique", "import")]
             )
@@ -98,7 +103,7 @@ class AccountJournal(models.Model):
                 if self.type == "sale"
                 else [ncf for ncf in ncf_types if ncf not in ncf_external]
             )
-            return self._get_all_ncf_types(res)
+            return self._get_all_ncf_types(res, invoice)
         else:
             counterpart_ncf_types = ncf_types_data[
                 "issued" if self.type == "sale" else "received"
@@ -107,7 +112,7 @@ class AccountJournal(models.Model):
         if invoice.type in ["out_refund", "in_refund"]:
             ncf_types = ["credit_note"]
 
-        return self._get_all_ncf_types(ncf_types)
+        return self._get_all_ncf_types(ncf_types, invoice)
 
     def _get_journal_codes(self):
         self.ensure_one()

--- a/l10n_do_accounting/models/account_journal.py
+++ b/l10n_do_accounting/models/account_journal.py
@@ -35,7 +35,8 @@ class AccountJournal(models.Model):
         """
 
         if self.company_id.l10n_do_ecf_issuer or (
-            not self.company_id.l10n_do_ecf_issuer
+            invoice
+            and not self.company_id.l10n_do_ecf_issuer
             and invoice.partner_id.l10n_do_dgii_tax_payer_type
             and invoice.partner_id.l10n_do_dgii_tax_payer_type != "non_payer"
         ):

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -102,12 +102,15 @@ class AccountMove(models.Model):
         compute="_compute_company_in_contingency",
     )
     is_l10n_do_internal_sequence = fields.Boolean(
-        string="Is internal sequence", compute="_compute_is_l10n_do_internal_sequence"
+        string="Is internal sequence", compute="_compute_l10n_latam_document_type"
     )
 
-    @api.depends("type", "l10n_latam_document_type_id.l10n_do_ncf_type")
-    def _compute_is_l10n_do_internal_sequence(self):
-        for invoice in self:
+    @api.depends("l10n_latam_available_document_type_ids")
+    @api.depends_context("internal_type")
+    def _compute_l10n_latam_document_type(self):
+        super(AccountMove, self)._compute_l10n_latam_document_type()
+
+        for invoice in self.filtered(lambda x: x.state == "draft"):
             invoice.is_l10n_do_internal_sequence = invoice.type in (
                 "out_invoice",
                 "out_refund",

--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -90,10 +90,7 @@
             </xpath>
             <field name="journal_id" position="after">
                 <field name="l10n_do_ecf_security_code" attrs="{
-                'invisible': [
-                '|', ('partner_id', '=', False),
-                '|', ('l10n_latam_country_code', '!=', 'DO'), ('is_l10n_do_internal_sequence', '=', False)
-                ]}"/>
+                'invisible': ['|', '|', ('partner_id', '=', False), ('l10n_latam_country_code', '!=', 'DO'), ('is_l10n_do_internal_sequence', '=', True)]}"/>
                 <field name="l10n_do_ecf_sign_date" invisible="1"/>
                 <field name="l10n_do_electronic_stamp" invisible="1"/>
             </field>

--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -90,7 +90,7 @@
             </xpath>
             <field name="journal_id" position="after">
                 <field name="l10n_do_ecf_security_code" attrs="{
-                'invisible': ['|', '|', ('partner_id', '=', False), ('l10n_latam_country_code', '!=', 'DO'), ('is_l10n_do_internal_sequence', '=', True)]}"/>
+                'invisible': ['|', '|', '|', ('partner_id', '=', False), ('l10n_latam_country_code', '!=', 'DO'), ('is_l10n_do_internal_sequence', '=', True), ('is_ecf_invoice', '=', False)]}"/>
                 <field name="l10n_do_ecf_sign_date" invisible="1"/>
                 <field name="l10n_do_electronic_stamp" invisible="1"/>
             </field>

--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -91,8 +91,8 @@
             <field name="journal_id" position="after">
                 <field name="l10n_do_ecf_security_code" attrs="{
                 'invisible': [
-                '|', ('is_ecf_invoice', '=', False),
-                '|', ('l10n_latam_country_code', '!=', 'DO'), ('is_l10n_do_internal_sequence', '=', True)
+                '|', ('partner_id', '=', False),
+                '|', ('l10n_latam_country_code', '!=', 'DO'), ('is_l10n_do_internal_sequence', '=', False)
                 ]}"/>
                 <field name="l10n_do_ecf_sign_date" invisible="1"/>
                 <field name="l10n_do_electronic_stamp" invisible="1"/>


### PR DESCRIPTION
- improve `l10n_do_ecf_security_code` field visibility. **It should only be visible if non-internal ECF purchase invoice**
- improve `is_l10n_do_internal_sequence` compute extending `_compute_l10n_latam_document_type()` function
- improve the way ECF document types are shown. Consider purchase invoice can be ECF even if company is not ECF issuer
- improve the way `is_ecf_invoice` field is computed

🔴 python code modification
🔴 xml file modification