### PR TITLE
[FIX] l10n_do_accounting: fix *inconsistent compute_sudo* warning

### DIFF
--- a/l10n_do_accounting/__init__.py
+++ b/l10n_do_accounting/__init__.py
@@ -76,9 +76,10 @@ def migrate_invoice_fields(env):
                     reference, income_type, anulation_type, origin_out
                     FROM account_invoice
                     WHERE move_name = '%s'
-                    AND state != 'draft';
+                    AND state != 'draft'
+                    AND company_id = %s;
                     """
-                env.cr.execute(query % invoice.name)
+                env.cr.execute(query % invoice.name, company.id)
                 data = env.cr.fetchone()
                 if data:
                     _logger.info(
@@ -135,9 +136,10 @@ def migrate_invoice_fields(env):
                         reference, expense_type, anulation_type, origin_out
                         FROM account_invoice
                         WHERE move_name = '%s'
-                        AND state != 'draft';
+                        AND state != 'draft'
+                        AND company_id = %s;
                         """
-                    env.cr.execute(query % invoice.name)
+                    env.cr.execute(query % invoice.name, company.id)
                     data = env.cr.fetchone()
                     if data:
                         _logger.info(

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -100,7 +100,9 @@ class AccountMove(models.Model):
         compute="_compute_company_in_contingency",
     )
     is_l10n_do_internal_sequence = fields.Boolean(
-        string="Is internal sequence", compute="_compute_l10n_latam_document_type"
+        string="Is internal sequence",
+        compute="_compute_l10n_latam_document_type",
+        store=True,
     )
 
     @api.depends(


### PR DESCRIPTION
An `inconsistent compute_sudo` log warning is shown when not all fields computed inside a function are consistent on their `store=True` behaviour.