### PR TITLE
[13.0] l10n_do_accounting: fixes & improvements

### DIFF
--- a/l10n_do_accounting/i18n/es_DO.po
+++ b/l10n_do_accounting/i18n/es_DO.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-10 18:26+0000\n"
-"PO-Revision-Date: 2020-12-10 18:26+0000\n"
+"POT-Creation-Date: 2021-01-14 17:33+0000\n"
+"PO-Revision-Date: 2021-01-14 17:33+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -507,6 +507,12 @@ msgstr "Envío diferido"
 #: model:ir.model.fields,field_description:l10n_do_accounting.field_account_move_cancel__display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
+
+#. module: l10n_do_accounting
+#: code:addons/l10n_do_accounting/models/l10n_latam_document_type.py:0
+#, python-format
+msgid "Document number %s doesn't match expected pattern"
+msgstr "El NCF %s no coincide con la estructura esperada"
 
 #. module: l10n_do_accounting
 #: model_terms:ir.ui.view,arch_db:l10n_do_accounting.view_document_type_filter

--- a/l10n_do_accounting/models/l10n_latam_document_type.py
+++ b/l10n_do_accounting/models/l10n_latam_document_type.py
@@ -1,4 +1,7 @@
-from odoo import models, fields
+from re import compile
+
+from odoo import models, fields, _
+from odoo.exceptions import ValidationError
 
 
 class L10nLatamDocumentType(models.Model):
@@ -79,5 +82,14 @@ class L10nLatamDocumentType(models.Model):
 
         if not document_number:
             return False
+
+        # NCF/ECF validation regex
+        regex = r"^((P?(?=.{11})B)|(?=.{13})E)(?!2)([0-4][1-7])(\d{8}|\d{10})$"
+        pattern = compile(regex)
+
+        if not bool(pattern.match(document_number)):
+            raise ValidationError(
+                _("Document number %s doesn't match expected pattern" % document_number)
+            )
 
         return document_number


### PR DESCRIPTION
- Create all (including ECF) sequence on journal `l10n_latam_use_documents` activation.
- Use regex to locally validate NCF/ECF structure. (This change only affect new documents. Is not retroactive)