### PR TITLE
[13.0] l10n_do_accounting: missing vat constraint bypass

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/migrations/13.0.1.0.1/post-init_document_type.py
+++ b/l10n_do_accounting/migrations/13.0.1.0.1/post-init_document_type.py
@@ -24,11 +24,11 @@ def update_document_types_vat_required(env):
     SET is_vat_required = 't'
     WHERE is_vat_required = 'f'
     AND l10n_do_ncf_type IN {ncf_types}
-    AND country_id = {company}
+    AND country_id = {country}
     """
     env.cr.execute(
         query.format(
-            ncf_types=tuple(l10n_do_ncf_types), company=env.ref("base.do").id
+            ncf_types=tuple(l10n_do_ncf_types), country=env.ref("base.do").id
         )
     )
     _logger.info("All Document Types set is_vat_required = True")

--- a/l10n_do_accounting/migrations/13.0.1.0.1/post-init_document_type.py
+++ b/l10n_do_accounting/migrations/13.0.1.0.1/post-init_document_type.py
@@ -31,7 +31,7 @@ def update_document_types_vat_required(env):
             ncf_types=tuple(l10n_do_ncf_types), company=env.ref("base.do").id
         )
     )
-    _logger.log(25, "All Document Types set is_vat_required = True")
+    _logger.info("All Document Types set is_vat_required = True")
 
 
 def migrate(cr, version):

--- a/l10n_do_accounting/migrations/13.0.1.0.1/post-init_document_type.py
+++ b/l10n_do_accounting/migrations/13.0.1.0.1/post-init_document_type.py
@@ -1,0 +1,40 @@
+import logging
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+
+def update_document_types_vat_required(env):
+    l10n_do_ncf_types = [
+        "fiscal",
+        "debit_note",
+        "informal",
+        "special",
+        "governmental",
+        "export",
+        "e-fiscal",
+        "e-debit_note",
+        "e-informal",
+        "e-special",
+        "e-governmental",
+        "e-export",
+    ]
+    query = """
+    UPDATE l10n_latam_document_type
+    SET is_vat_required = 't'
+    WHERE is_vat_required = 'f'
+    AND l10n_do_ncf_type IN {ncf_types}
+    AND country_id = {company}
+    """
+    env.cr.execute(
+        query.format(
+            ncf_types=tuple(l10n_do_ncf_types), company=env.ref("base.do").id
+        )
+    )
+    _logger.log(25, "All Document Types set is_vat_required = True")
+
+
+def migrate(cr, version):
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    update_document_types_vat_required(env)

--- a/l10n_do_accounting/migrations/13.0.1.0.1/pre-init_document_type.py
+++ b/l10n_do_accounting/migrations/13.0.1.0.1/pre-init_document_type.py
@@ -9,9 +9,9 @@ def update_document_types_not_vat_required(env):
     UPDATE l10n_latam_document_type
     SET is_vat_required = 'f'
     WHERE is_vat_required = 't'
-    AND country_id = {company}
+    AND country_id = {country}
     """
-    env.cr.execute(query.format(company=env.ref("base.do").id))
+    env.cr.execute(query.format(country=env.ref("base.do").id))
     _logger.info("All Document Types set is_vat_required = False")
 
 

--- a/l10n_do_accounting/migrations/13.0.1.0.1/pre-init_document_type.py
+++ b/l10n_do_accounting/migrations/13.0.1.0.1/pre-init_document_type.py
@@ -1,0 +1,21 @@
+import logging
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+
+def update_document_types_not_vat_required(env):
+    query = """
+    UPDATE l10n_latam_document_type
+    SET is_vat_required = 'f'
+    WHERE is_vat_required = 't'
+    AND country_id = {company}
+    """
+    env.cr.execute(query.format(company=env.ref("base.do").id))
+    _logger.log(25, "All Document Types set is_vat_required = False")
+
+
+def migrate(cr, version):
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    update_document_types_not_vat_required(env)

--- a/l10n_do_accounting/migrations/13.0.1.0.1/pre-init_document_type.py
+++ b/l10n_do_accounting/migrations/13.0.1.0.1/pre-init_document_type.py
@@ -12,7 +12,7 @@ def update_document_types_not_vat_required(env):
     AND country_id = {company}
     """
     env.cr.execute(query.format(company=env.ref("base.do").id))
-    _logger.log(25, "All Document Types set is_vat_required = False")
+    _logger.info("All Document Types set is_vat_required = False")
 
 
 def migrate(cr, version):


### PR DESCRIPTION
Databases which exists before `_check_invoice_type_document_type()` constrains implementation may have partners with missing vat. This cause obvious errors when updating the module.

This scrips disable document types "requiredness (this word even exists?)" after init (module update process) and re-activate this attribute once again after update finished.

This PR also implements a simple logging function that logs partners names that have fiscal invoices and missing vat.