### PR TITLE
[FIX] l10n_do_accounting: migrations - missing vat constraint bypass

### DIFF
--- a/l10n_do_accounting/migrations/13.0.1.0.1/post-init_document_type.py
+++ b/l10n_do_accounting/migrations/13.0.1.0.1/post-init_document_type.py
@@ -42,10 +42,16 @@ def log_missing_partner_vat_invoices(env):
     ON (journal.id = move.journal_id)
     JOIN res_partner AS partner
     ON (partner.id = move.partner_id)
+    JOIN l10n_latam_document_type as latam_document
+    ON (latam_document.id = move.l10n_latam_document_type_id)
     WHERE journal.l10n_latam_use_documents = 't'
+    AND latam_document.is_vat_required = 't'
     AND move.company_id = {company}
-    AND partner.vat IS NULL
-    OR COALESCE(TRIM(vat), '') = '';
+    AND
+    (
+        (partner.vat IS NULL)
+        OR (COALESCE(TRIM(vat), '') = '')
+    );
     """
     domain = [("partner_id.country_id", "=", env.ref("base.do").id)]
     for company in env["res.company"].search(domain):


### PR DESCRIPTION
Consider only document types which vat is required for logger