### PR TITLE
[13.0][IMP] l10n_do_accounting: allow set contact parent

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "13.0.1.0.1",
+    "version": "13.0.1.0.2",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/models/res_partner.py
+++ b/l10n_do_accounting/models/res_partner.py
@@ -56,6 +56,13 @@ class Partner(models.Model):
 
     def _check_l10n_do_fiscal_fields(self, vals):
 
+        if self.parent_id:
+            # Do not perform any check because child contacts
+            # have readonly fiscal field. This also allows set
+            # contacts parent, even if this changes any of its
+            # fiscal fields.
+            return
+
         fiscal_fields = [
             field
             for field in ["name", "vat", "country_id"]  # l10n_do_dgii_tax_payer_type ?


### PR DESCRIPTION
A contact to which already have been issued fiscal invoices may need to be set as a child contact. This action causes some fiscal fields to auto change to its parents values, causing the exception to raise.

This PR allows to perform this use case and skip the validation.