### PR TITLE
[FIX] l10n_do_accounting: only perform validation on valid records

### DIFF
--- a/l10n_do_accounting/models/res_partner.py
+++ b/l10n_do_accounting/models/res_partner.py
@@ -56,7 +56,7 @@ class Partner(models.Model):
 
     def _check_l10n_do_fiscal_fields(self, vals):
 
-        if self.parent_id:
+        if not self or self.parent_id:
             # Do not perform any check because child contacts
             # have readonly fiscal field. This also allows set
             # contacts parent, even if this changes any of its


### PR DESCRIPTION
When creating a contact and adding a child contact to it, in an instance of the write self comes without records, therefore doesn't make sense to perform validations and avoids false-positives. 