### PR TITLE
[14.0] [FIX] Refactor "_compute_name" and "_get_last_sequence" method

### DIFF
--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -134,7 +134,26 @@
             </xpath>
         </field>
     </record>
-
+    <record id="view_out_invoice_tree" model="ir.ui.view">
+        <field name="name">view.out.invoice.tree</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_out_invoice_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="l10n_latam_document_number"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_in_invoice_tree" model="ir.ui.view">
+        <field name="name">view.in.invoice.tree</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_in_invoice_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="l10n_latam_document_number"/>
+            </xpath>
+        </field>
+    </record>
     <!-- Exclude debit notes from actual vendor/customer invoices actions -->
     <record id="account.action_move_out_invoice_type" model="ir.actions.act_window">
         <field name="domain">[('move_type', '=', 'out_invoice'), ('debit_origin_id', '=', False)]</field>

--- a/l10n_do_accounting/views/report_invoice.xml
+++ b/l10n_do_accounting/views/report_invoice.xml
@@ -6,7 +6,7 @@
         <xpath expr="//t[@t-set='o']" position="after">
             <!-- When is a e-CF representation, additional info is displayed -->
             <t t-set="ecf_representation" t-value="o.company_id.l10n_do_ecf_issuer"/>
-            <t t-set="is_l10n_do_invoice" t-value="o.l10n_latam_use_documents and o.company_id.country_id and o.company_id.l10n_do_country_code == 'DO'"/>
+            <t t-set="is_l10n_do_invoice" t-value="o.l10n_latam_use_documents and o.company_id.country_id and o.company_id.country_code == 'DO'"/>
         </xpath>
 
         <!-- Hide when l10n do invoice -->

--- a/l10n_do_accounting/views/report_templates.xml
+++ b/l10n_do_accounting/views/report_templates.xml
@@ -4,29 +4,29 @@
     <template id="web_address_layout_inherited" inherit_id="web.address_layout">
         <!-- do not show company address on document header  -->
         <xpath expr="//t[@t-if='address']/div" position="attributes">
-            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.l10n_do_country_code != "DO")</attribute>
+            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.country_code != "DO")</attribute>
         </xpath>
     </template>
 
     <!-- do not show partner address on document header when l10n do invoice -->
     <template id="external_layout_clean_inherited" inherit_id="web.external_layout_clean">
         <xpath expr="//div[hasclass('o_clean_header')]/div/div[@name='company_address']" position="attributes">
-            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.l10n_do_country_code != "DO")</attribute>
+            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.country_code != "DO")</attribute>
         </xpath>
     </template>
     <template id="external_layout_standard_inherited" inherit_id="web.external_layout_standard">
         <xpath expr="//div[@name='company_address']" position="attributes">
-            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.l10n_do_country_code != "DO")</attribute>
+            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.country_code != "DO")</attribute>
         </xpath>
     </template>
     <template id="external_layout_background_inherited" inherit_id="web.external_layout_background">
         <xpath expr="//div[hasclass('company_address')]" position="attributes">
-            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.l10n_do_country_code != "DO")</attribute>
+            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.country_code != "DO")</attribute>
         </xpath>
     </template>
     <template id="external_layout_boxed_inherited" inherit_id="web.external_layout_boxed">
         <xpath expr="//div[@name='company_address']" position="attributes">
-            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.l10n_do_country_code != "DO")</attribute>
+            <attribute name="t-if">doc_model != "account.move" or (doc_model == "account.move" and o.company_id.country_code != "DO")</attribute>
         </xpath>
     </template>
 

--- a/l10n_do_accounting/wizard/account_move_cancel.py
+++ b/l10n_do_accounting/wizard/account_move_cancel.py
@@ -32,7 +32,7 @@ class AccountMoveCancel(models.TransientModel):
                         "already in 'Cancelled' state."
                     )
                 )
-            if invoice.invoice_payment_state != "not_paid":
+            if invoice.payment_state != "not_paid":
                 raise UserError(
                     _(
                         "Selected invoice(s) cannot be cancelled as they are "


### PR DESCRIPTION
1- Without this patch, when l10n_latam_invoice_document and l10n_do_accounting modules are installed, invoices always compute first number in both sequence fields "name" and "l10n_latam_document_number"

NOTE: This is a temporary fix due to method substitutions

2- Replace non-existent field invoice_payment_state with payment_state.

3- Added l10n_latam_document_number to invoice trees
 