### PR TITLE
[13.0][IMP] l10n_do_accounting: avoid contraint validation of unique sequence if invoice is not from same year

### DIFF
--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -217,6 +217,7 @@ class AccountMove(models.Model):
                     move2.ref = move.ref
                     AND move2.company_id = move.company_id
                     AND move2.type = move.type
+                    AND extract(year from move2.date) = extract(year from move.date)
                     AND move2.id != move.id
                 WHERE move.id IN %s AND move2.state = 'posted'
             """,


### PR DESCRIPTION
When a company generates a large number of fiscal sequences, the current constraint on method `_check_unique_sequence_number` located at `l10n_do_accounting\models\account_move.py:203` might become a bug by not letting the user generate a new sequence. 

**Steps to Reproduce**
Steps to reproduce the behavior:
1. User generates several invoices over the years to the a recurrent partner
1. Since the sequences can be restarted to 01 again
1. When it does, there is a possibility of the user generating an invoice for a partner when the next number is one already used for the same partner in prior years

**Expected behavior**
Improve the method `_check_unique_sequence_number` to consider the invoice year when validating if and invoice with that sequence number already exists. By doing this, a user could generate a invoice for the same partner, with the same sequence number as long as the sequence is from another year.