### PR TITLE
[13.0][FIX] l10n_do_accounting: fixes & improvements

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "13.0.1.0.5",
+    "version": "13.0.1.0.6",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -157,7 +157,9 @@ class AccountMove(models.Model):
     def _compute_l10n_do_electronic_stamp(self):
 
         l10n_do_ecf_invoice = self.filtered(
-            lambda i: i.is_ecf_invoice and i.l10n_do_ecf_security_code
+            lambda i: i.is_ecf_invoice
+            and i.is_l10n_do_internal_sequence
+            and i.l10n_do_ecf_security_code
         )
 
         for invoice in l10n_do_ecf_invoice:

--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -70,8 +70,8 @@
                     'readonly': [('state','!=','draft')]
                 }"/>
                 <field name="l10n_do_ecf_modification_code" attrs="{
-                    'invisible':['|', '|', '|', '&amp;', ('type', 'not in', ('in_refund', 'out_refund')), ('is_debit_note', '=', False), '&amp;', ('type', 'in', ('in_refund', 'out_refund')), ('is_ecf_invoice', '=', False), '&amp;', ('is_debit_note', '=', True), ('is_ecf_invoice', '=', False), ('l10n_latam_country_code', '!=', 'DO')],
-                    'required': ['&amp;', ('is_ecf_invoice', '=', True), '|', ('type', 'in', ('in_refund', 'out_refund')), ('is_debit_note', '=', True)],
+                    'invisible':['|', '|', '|', '&amp;', ('type', '!=', 'out_refund'), ('is_debit_note', '=', False), '&amp;', ('type', '=', 'out_refund'), ('is_ecf_invoice', '=', False), '&amp;', ('is_debit_note', '=', True), ('is_ecf_invoice', '=', False), ('l10n_latam_country_code', '!=', 'DO')],
+                    'required': ['&amp;', ('is_ecf_invoice', '=', True), '|', ('type', '=', 'out_refund'), ('is_debit_note', '=', True)],
                 }"/>
             </xpath>
             <xpath expr="//field[@name='l10n_latam_document_number']" position="after">


### PR DESCRIPTION
- [FIX] l10n_do_accounting: only compute electronic stamp for internal sequence invoices

Prevent this error when creating Purchase electronic invoice with ECF Security Code
```
  File "/Users/joselopez/PycharmProjects/indexa/l10n-dominicana/l10n_do_accounting/models/account_move.py", line 192, in _compute_l10n_do_electronic_stamp
    qr_string += "FechaFirma=%s&" % invoice.l10n_do_ecf_sign_date.strftime(
AttributeError: 'bool' object has no attribute 'strftime'
```

- [IMP] l10n_do_accounting: ecf modification code only required on sale documents

