### PR TITLE
[13.0][IMP] l10n_do_accounting: show revert wizard document type field

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "13.0.1.1.6",
+    "version": "13.0.1.2.6",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/wizard/account_move_reversal_views.xml
+++ b/l10n_do_accounting/wizard/account_move_reversal_views.xml
@@ -14,7 +14,7 @@
             </field>
             <field name="l10n_latam_document_type_id" position="attributes">
                 <attribute name="attrs">{
-                    'invisible': ['|', '&amp;', ('refund_method', '=', 'refund'), ('l10n_latam_country_code', '!=', 'DO'), ('l10n_latam_country_code', '=', 'DO')],
+                    'invisible': ['|', '&amp;', ('refund_method', '=', 'refund'), ('l10n_latam_country_code', '!=', 'DO'), ('move_type', '=', 'out_invoice')],
                     'required': [('l10n_latam_use_documents', '=', True), ('refund_method', '!=', 'refund')],
                 }</attribute>
             </field>


### PR DESCRIPTION
Debido a que a partir de la implementación de la Facturación Electrónica en el país podemos recibir facturas serie "B" y "E" por parte de nuestros proveedores, se habilita la opción de seleccionar el tipo de comprobante para la nota de crédito.

Este campo se mantiene invisible para notas de crédito de clientes.