### PR TITLE
[13.0][REF] l10n_do_accounting: remove fields from form view

### DIFF
--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -92,8 +92,6 @@
             <field name="journal_id" position="after">
                 <field name="l10n_do_ecf_security_code" attrs="{
                 'invisible': ['|', '|', '|', ('partner_id', '=', False), ('l10n_latam_country_code', '!=', 'DO'), ('is_l10n_do_internal_sequence', '=', True), ('is_ecf_invoice', '=', False)]}"/>
-                <field name="l10n_do_ecf_sign_date" invisible="1"/>
-                <field name="l10n_do_electronic_stamp" invisible="1"/>
             </field>
 
             <!-- only computed when l10n_do ecf invoice -->


### PR DESCRIPTION
De ninguna manera una compañía debe emitir Facturas Electrónicas a distintos ambientes. Es decir, si la compañía está emitiendo al ambiente de pruebas, no debe en esa misma base de datos emitir ECF a producción, y viceversa.