### PR TITLE
[13.0][FIX] l10n_do_accounting: correctly get electronic stamp MontoTotal

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "13.0.1.4.9",
+    "version": "13.0.1.4.10",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -192,7 +192,7 @@ class AccountMove(models.Model):
                     invoice.invoice_date or fields.Date.today()
                 ).strftime("%d-%m-%Y")
             qr_string += "MontoTotal=%s&" % (
-                "%f" % abs(invoice.amount_total_signed)
+                "%f" % sum(invoice.line_ids.mapped("credit"))
             ).rstrip("0").rstrip(".")
             if not is_rfc:
                 qr_string += "FechaFirma=%s&" % invoice.l10n_do_ecf_sign_date.strftime(


### PR DESCRIPTION
Este PR resuelve un issue en el cálculo del MontoTotal que forma parte del URL del electronic stamp (QR) de las facturas electrónicas dominicanas.

Cuando se aplican retenciones en lineas de factura (como es el caso de los Comprobantes de Compra Electrónicas), se generaba una inconsistencia entre la información enviada a la DGII y la compuesta en la URL del QR. Con este PR se obtiene el MontoTotal de la suma de los apuntes y no del Total facturado.