### PR TITLE
ADD move_type domain to enable first sequence compute

### DIFF
--- a/l10n_do_accounting/migrations/14.0.1.3.0/post-init_migrate_fields.py
+++ b/l10n_do_accounting/migrations/14.0.1.3.0/post-init_migrate_fields.py
@@ -20,7 +20,7 @@ def migrate_ref_field(env):
     WHERE l10n_do_fiscal_number IS NULL
     AND LENGTH(ref) IN (11, 13)
     AND ref LIKE 'B%' OR ref LIKE 'E%'
-    AND type != 'entry'
+    AND move_type != 'entry'
     """
     env.cr.execute(query)
     _logger.info("Migrating account_move ref field to l10n_do_fiscal_number")

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -171,6 +171,7 @@ class AccountMove(models.Model):
                 self.search_count(
                     [
                         ("company_id", "=", invoice.company_id.id),
+                        ('move_type', '=', invoice.move_type),
                         (
                             "l10n_latam_document_type_id",
                             "=",


### PR DESCRIPTION
Escenario de ejemplo solucionado: Al registrar la primera factura de cliente con crédito fiscal (B01), ya existiendo facturas de crédito fiscal de proveedores, este search_count retornaba esas facturas de proveedor, no permitiendo entonces asignar la primera secuencia manualmente