### PR TITLE
[14.0][FIX] l10n_do_accounting: move_type domain to enable first sequence compute

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "14.0.1.7.10",
+    "version": "14.0.1.7.9",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "14.0.1.7.8",
+    "version": "14.0.1.7.10",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -171,6 +171,7 @@ class AccountMove(models.Model):
                 self.search_count(
                     [
                         ("company_id", "=", invoice.company_id.id),
+                        ('move_type', '=', invoice.move_type),
                         (
                             "l10n_latam_document_type_id",
                             "=",


### PR DESCRIPTION
Escenario de ejemplo solucionado: Al registrar la primera factura de cliente con crédito fiscal (B01), ya existiendo facturas de crédito fiscal de proveedores, este search_count retornaba esas facturas de proveedor, no permitiendo entonces asignar la primera secuencia manualmente