### PR TITLE
[15.0][REF] l10n_do_accounting: don't use DOP on tests

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "15.0.0.4.5",
+    "version": "15.0.0.4.6",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/tests/common.py
+++ b/l10n_do_accounting/tests/common.py
@@ -9,7 +9,7 @@ class L10nDOTestsCommon(AccountTestInvoicingCommon):
 
         cls.company_data["company"].write(
             {
-                "currency_id": cls.env.ref("base.DOP").id,
+                # "currency_id": cls.env.ref("base.DOP").id,
                 "name": "INDEXA SRL",
                 "vat": "131793916",
                 "country_id": cls.env.ref("base.do").id,


### PR DESCRIPTION
Use of DOP may break Odoo tests because all tests share the same company.