### PR TITLE
[13.0][FIX] l10n_do_accounting: prevent dependency chain to be broken on button_cancel()

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "13.0.1.8.18",
+    "version": "13.0.1.9.18",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -314,7 +314,7 @@ class AccountMove(models.Model):
         ):
             raise AccessError(_("You are not allowed to cancel Fiscal Invoices"))
 
-        if fiscal_invoice:
+        if fiscal_invoice and not self.env.context.get("skip_cancel_wizard", False):
             action = self.env.ref(
                 "l10n_do_accounting.action_account_move_cancel"
             ).read()[0]

--- a/l10n_do_accounting/wizard/account_move_cancel.py
+++ b/l10n_do_accounting/wizard/account_move_cancel.py
@@ -39,10 +39,10 @@ class AccountMoveCancel(models.TransientModel):
                         "already in 'Paid' state."
                     )
                 )
-            invoice.write(
-                {
-                    "state": "cancel",
-                    "l10n_do_cancellation_type": self.l10n_do_cancellation_type,
-                }
-            )
+
+            # we call button_cancel() so dependency chain is
+            # not broken in other modules extending that function
+            invoice.with_context(skip_cancel_wizard=True).button_cancel()
+            invoice.l10n_do_cancellation_type = self.l10n_do_cancellation_type
+
         return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
Because `account.move.cancel` wizard is raised when calling `button_cancel()` from dominican fiscal invoices, use the same function to correctly cancel them, so dependency chain is not broken when using other modules extending that particular function.