### PR TITLE
[13.0][REF] l10_do_pos: posticket refactored and updated

### DIFF
--- a/l10n_do_pos/static/src/css/pos.css
+++ b/l10n_do_pos/static/src/css/pos.css
@@ -12,6 +12,33 @@
 }
 
 /* c) The receipt screen */
+.pos-receipt .pos-receipt-amount {
+    font-size: 19px;
+    padding-left: 3em;
+}
+.pos-receipt .pos-receipt-left-padding {
+    padding-left: 5%;
+}
+.pos-receipt-contact-before{
+    text-align: center;
+    font-size: 75%;
+}
+
+hr {
+  border: none;
+  border-top: 1px dotted;
+  height: 1px;
+  width: 103%;
+}
+
+.dotted_line {
+    border: 1px dashed black;
+    border-left: none;
+    border-right: none;
+    border-top: none;
+    padding: .5em 0;
+    margin: .9em 0 0 0;
+}
 
 .dotted_ticket_title {
     border: 1px dashed black;

--- a/l10n_do_pos/static/src/xml/posticket.xml
+++ b/l10n_do_pos/static/src/xml/posticket.xml
@@ -3,6 +3,7 @@
         <t t-extend="OrderReceipt">
                 <!-- Information -->
                 <t t-jquery=".pos-receipt-contact" t-operation="after">
+                    <t t-if="pos.company.country_id == '61,República Dominicana'">
                         <div class="pos-receipt-contact">
                                 <div>RES-DGII: 23-2009 DEL 6/ABRIL/2009</div>
                                 <em> COMPROBANTE AUTORIZADO POR LA DGII</em>
@@ -36,15 +37,10 @@
                                 </strong>
                             </t>
                                              <hr/>
-                            <t t-if="order.l10n_latam_document_type.doc_code_prefix != 'B01'" style="tex">
-                                <strong> Factura Para Consumidor Final</strong>
-                                <br/>
+                            <t t-if="order.l10n_latam_document_type" style="tex">
+                                Factura de: <t t-esc="order.l10n_latam_document_type.name"/>
                             </t>
-                            <t t-else="">
-                                <strong>Factura Para Credito Fiscal</strong>
-                                <br/>
-                            </t>
-                                             <hr/>
+                         <hr/>
                         </div>
                     <div class="pos-receipt-left-padding" margin="20%">
                         <strong>DESCRIPCION</strong>
@@ -53,9 +49,9 @@
                     </div>
                     <hr/>
                 </t>
+            </t>
 
                 <!-- orderlines -->
-
                 <t t-jquery=".orderlines" t-operation="inner">
                     <table class="receipt-orderlines">
                     <tr t-foreach='receipt.orderlines' t-as='line'>
@@ -100,6 +96,6 @@
                     </tr>
                     </table>
                 </t>
-        </t>
+            </t>
 </templates>
 

--- a/l10n_do_pos/static/src/xml/posticket.xml
+++ b/l10n_do_pos/static/src/xml/posticket.xml
@@ -1,241 +1,105 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template">
-    <t t-extend="OrderReceipt">
-        <t t-jquery=".pos-receipt" t-operation="replace">
-            <div class="pos-receipt">
-                <div class="pos-receipt-center-align">
-                    <t t-if='receipt.company.logo'>
-                        <img class="pos-receipt-logo" t-att-src='receipt.company.logo' alt="Logo"/>
-                        <br/>
-                    </t>
-                    <t t-if="widget.pos.company">
-                        <t t-esc="order.pos.company.name"/>
-                        <br/>
-                    </t>
-                    <t t-if="widget.pos.company.street">
-                        <t t-esc="widget.pos.company.street"/>,
-                    </t>
-                    <t t-if="widget.pos.company.street2">
-                        <t t-esc="widget.pos.company.street2"/>
-                    </t>
-                    <t t-if="widget.pos.company.vat">
-                        <br/>
-                        <strong>RNC:</strong>
-                        <t t-esc="widget.pos.company.vat"/>
-                        <br/>
-                    </t>
+        <t t-extend="OrderReceipt">
+                <!-- Information -->
+                <t t-jquery=".pos-receipt-contact" t-operation="after">
+                        <div class="pos-receipt-contact">
+                                <div>RES-DGII: 23-2009 DEL 6/ABRIL/2009</div>
+                                <em> COMPROBANTE AUTORIZADO POR LA DGII</em>
+                        </div>
                     <br/>
-                    <t t-esc="order.name"/>
-                    <br/>
-                    <t t-if="order.l10n_latam_document_type and order.l10n_latam_document_number">
-                        <div class="pos-receipt-center-align dotted_ticket_title">
-                            <strong>Factura de
-                                <t t-esc="order.l10n_latam_document_type.name"/>
-                            </strong>
+                    <t t-set="client" t-value="widget.pos.get_client()"/>
+                    <t t-if="client">
+                        <strong>Cliente:</strong>
+                        <t t-esc="client.name || ''"/>
+                        <br/>
+                        <t t-if="client.vat">
+                            <strong>RNC/Ced:</strong>
+                            <t t-esc="client.vat"/>
                             <br/>
-                            <strong>NCF:
-                                <t t-esc="order.l10n_latam_document_number"/>
-                            </strong>
+                        </t>
+                        <strong>NIF:</strong> <t t-esc="order.name"/>
+                        <br/>
+                        <strong>NCF:</strong> <t t-esc="order.l10n_latam_document_number"/>
+                        <br/>
+                        <t t-if="client.barcode">
+                            <strong>Código:</strong>
+                            <t t-esc="client.barcode"/>
+                            <br/>
+                        </t>
+                    </t>
+                     <div style="text-align: center">
                             <t t-if="order.l10n_do_is_return_order">
                                 <br/>
                                 <strong>NCF Modificado:
                                     <t t-esc="order.l10n_do_origin_ncf"/>
                                 </strong>
                             </t>
-                            <t t-if="order.l10n_latam_document_type.doc_code_prefix != 'B02'">
+                                             <hr/>
+                            <t t-if="order.l10n_latam_document_type.doc_code_prefix != 'B01'" style="tex">
+                                <strong> Factura Para Consumidor Final</strong>
                                 <br/>
-                                <strong>Válida hasta:
-                                    <t t-esc="order.l10n_do_ncf_expiration_date"/>
-                                </strong>
                             </t>
+                            <t t-else="">
+                                <strong>Factura Para Credito Fiscal</strong>
+                                <br/>
+                            </t>
+                                             <hr/>
                         </div>
-                    </t>
-                </div>
-                <br/>
-                <div class="receipt-phone">
-                    <strong>Fecha....:</strong>
-                    <t t-esc="order.formatted_validation_date"/>
-                    <br/>
-                     <t t-set="client" t-value="widget.pos.get_client()"/>
-                    <t t-if="client">
-                        <strong>Cliente..:</strong>
-                        <t t-esc="client.name || ''"/>
-                        <br/>
-                        <t t-if="client.vat">
-                            <strong>RNC/Céd..:</strong>
-                            <t t-esc="client.vat"/>
-                            <br/>
-                        </t>
-                        <t t-if="client.barcode">
-                            <strong>Código..:</strong>
-                            <t t-esc="client.barcode"/>
-                            <br/>
-                        </t>
-                    </t>
-                    <!--TODO: What is this field?-->
-                    <!--<strong>Sucursal.:</strong>-->
-                    <!--<t t-esc="receipt.shop.name"/>-->
-                    <!--<br/>-->
-                    <strong>Telefono.:</strong>
-                    <t t-esc="widget.pos.company.phone || ''"/>
-                    <br/>
-                </div>
-                <div class="receipt-phone">
-                    <strong>Cajero/a.:</strong>
-                    <t t-esc="widget.pos.user.name"/>
-                </div>
-                <t t-if="widget.pos.config.seller_and_cashier_ticket">
-                    <t t-set="cashier" t-value="widget.pos.get_cashier()"/>
-                    <t t-if="cashier">
-                        <t t-if="cashier.name != widget.pos.user.name">
-                            <div class="receipt-phone">
-                                <strong>Vendedor/a.:</strong>
-                                <t t-esc="cashier.name"/>
-                            </div>
-                        </t>
-                    </t>
+                    <div class="pos-receipt-left-padding" margin="20%">
+                        <strong>DESCRIPCION</strong>
+                        <strong style="padding-left: 2.5em">ITBIS</strong>
+                        <strong class="pos-receipt-right-align"> VALOR</strong>
+                    </div>
+                    <hr/>
                 </t>
-                <br/>
-                <div style="border-bottom: 1px solid black;"/>
-                <table class="receipt-orderlines">
-                    <thead>
-                        <tr>
-                            <th class="pos-receipt-center-align" width="13%">
-                                <strong>Cant.</strong>
-                            </th>
-                            <th width="35%">
-                                <strong>Producto</strong>
-                            </th>
-                            <th width="16%">
-                                <strong>$/Und.</strong>
-                            </th>
-                            <th width="12%">
-                                <strong>ITBIS</strong>
-                            </th>
-                            <th class="pos-right-align" width="20%">
-                                <strong>Valor</strong>
-                            </th>
-                            <th width="4%">
-                                <strong></strong>
-                            </th>
-                        </tr>
-                    </thead>
-                    <tr>
-                        <td>
-                            <div style="border-bottom: 1px solid black;"/>
-                        </td>
-                        <td>
-                            <div style="border-bottom: 1px solid black;"/>
-                        </td>
-                        <td>
-                            <div style="border-bottom: 1px solid black;"/>
-                        </td>
-                        <td>
-                            <div style="border-bottom: 1px solid black;"/>
-                        </td>
-                        <td>
-                            <div style="border-bottom: 1px solid black;"/>
-                        </td>
-                        <td>
-                            <div style="border-bottom: 1px solid black;"/>
-                        </td>
-                    </tr>
-                    <tr t-as="orderline" t-foreach="orderlines">
-                        <td class="pos-receipt-center-align" width="13%">
-                            <t t-esc="orderline.get_quantity_str_with_unit()"/>
-                        </td>
-                        <td width="35%">
-                            <t t-esc="orderline.get_product().display_name"/>
-                            <t t-if="widget.pos.config.on_product_line">
-                                <div class="pos-disc-font">
-                                    <t t-esc="orderline.get_order_line_comment()"/>
-                                </div>
-                            </t>
-                            <t t-if="orderline.get_discount() &gt;0">
-                                <div class="pos-disc-font">With a<t t-esc="orderline.get_discount()"/>% discount
-                                </div>
-                            </t>
-                        </td>
-                        <td width="16%">
-                            <t t-esc="widget.format_currency_no_symbol(orderline.price)"/>
-                        </td>
-                        <td width="12%">
-                            <t t-esc="widget.format_currency_no_symbol(orderline.get_tax())"/>
-                        </td>
-                        <td class="pos-right-align" width="20%">
-                            <t t-esc="widget.format_currency_no_symbol(orderline.get_display_price())"/>
-                        </td>
-                        <td width="4%">
-                            <t t-if="orderline.get_tax() === 0">
-                                <strong>E</strong>
-                            </t>
-                        </td>
-                    </tr>
-                </table>
-                <table>
-                    <br/>
-                    <div style="border-bottom: 1px dashed black"/>
-                </table>
-                <br/>
-                <div class="receipt-total">
-                    <div class="pos-receipt-right-align">
-                        SubTotal: <t t-esc="widget.format_currency_no_symbol(order.get_total_without_tax())"/>
-                    </div>
-                    <br/>
-                    <t t-as="taxdetail" t-foreach="order.get_tax_details()">
-                        <div class="pos-receipt-right-align">
-                            <span t-esc="taxdetail.name"/>: <span t-esc="widget.format_currency_no_symbol(taxdetail.amount)"/>
-                        </div>
-                        <br/>
-                    </t>
-                    <t t-if="receipt.total_discount">
-                        <td class="pos-receipt-right-align">
-                            Descuento: <span t-esc="widget.format_currency(receipt.total_discount)"/>
-                        </td>
-                        <br/>
-                    </t>
-                </div>
-                <div class="emph">
-                    <div class="pos-receipt-right-align">
-                        <strong>
-                            Total: <span t-esc="widget.format_currency(order.get_total_with_tax())"/>
-                        </strong>
-                    </div>
-                    <br/>
-                </div>
-                <br/>
-                <div class="receipt-paymentlines">
-                    <t t-as="line" t-foreach="paymentlines">
-                        <div class="pos-receipt-right-align">
-                            <span t-esc="line.name"/>:
-                            <t t-if="line.get_amount() > 0">
-                                <t t-esc="widget.format_currency_no_symbol(line.get_amount())"/>
-                            </t>
-                        </div>
-                        <br/>
-                    </t>
-                </div>
-                <br/>
-                <div class="receipt-change">
-                    <t t-if="order.get_change() > 0">
-                        <div class="pos-receipt-right-align">
-                            <strong>Cambio: </strong>
-                            <span t-esc="widget.format_currency_no_symbol(order.get_change())"/>
-                        </div>
-                        <br/>
-                    </t>
-                </div>
-                <br/>
-                <div class='before-footer' />
-                <!-- Footer -->
-                <div t-if='receipt.footer_html'  class="pos-receipt-center-align">
-                    <t t-raw='receipt.footer_html'/>
-                </div>
 
-                <div t-if='!receipt.footer_html and receipt.footer'  class="pos-receipt-center-align" style="white-space:pre-line">
-                    <t t-esc='receipt.footer'/>
-                </div>
-            </div>
+                <!-- orderlines -->
+
+                <t t-jquery=".orderlines" t-operation="inner">
+                    <table class="receipt-orderlines">
+                    <tr t-foreach='receipt.orderlines' t-as='line'>
+                        <t t-set='simple' t-value='(line.discount === 0 and line.unit_name === "Units" and line.quantity === 1 and !discount_to_show and !(line.display_discount_policy == "without_discount" &amp;&amp; line.price != line.price_lst))' />
+                        <t t-if='simple'>
+                            <tr style="font-size: small;">
+                                <td class="pos-receipt-left-align"><strong t-esc='line.product_name_wrapped[0]'/><br/><t t-call="OrderReceiptWrappedProductNameLines" style="font-size: small;"/></td>
+                                <td  class="pos-receipt-left-align" style="padding-right: 4.5em;"><t t-esc="widget.format_currency_no_symbol(line.tax)"/></td>
+                                <td class="pos-receipt-left-align" style="width: 5%"><t t-esc='widget.format_currency_no_symbol(line.price_display)' class="price_display pos-receipt-right-align"/></td>
+                            </tr>
+                            </t>
+                        <t t-if='!simple'>
+                            <tr style="font-size: small;">
+
+                                <td><strong t-esc='line.product_name_wrapped[0]'/><br/><t t-call="OrderReceiptWrappedProductNameLines"/><t t-if="line.display_discount_policy == 'without_discount' &amp;&amp; line.price != line.price_lst"><div class="pos-receipt-left-padding"><t t-esc="widget.format_currency_no_symbol(line.price_lst)" />-><div  t-esc="widget.format_currency_no_symbol(line.tax)" style="padding-left: 10em"/><t t-esc="widget.format_currency_no_symbol(line.price)" /></div></t>
+                                <t t-elif='line.discount !== 0'>
+                                <div class="pos-receipt-left-padding" style="margin-top: none;">
+                                    <t t-if="pos.config.iface_tax_included === 'total'">
+                                        <t t-esc="widget.format_currency_no_symbol(line.price_with_tax_before_discount)"/>
+                                    </t>
+                                    <t t-else="">
+                                        <t t-esc="widget.format_currency_no_symbol(line.price)"/>
+                                    </t>
+                                </div>
+                                </t>
+                                    <t t-if='line.discount !== 0'>
+                                        <div class="pos-receipt-left-padding">
+                                        Discount: <t t-esc='line.discount' />%
+                                        </div>
+                                    </t>
+                                    <div style=" font-size: small; margin-left: 1em;">
+                                        <t t-esc="Math.round(line.quantity * Math.pow(10, pos.dp['Product Unit of Measure'])) / Math.pow(10, pos.dp['Product Unit of Measure'])"/>
+                                        <t t-if='line.unit_name !== "Units"' t-esc='line.unit_name'/>
+                                        x
+                                        <t t-esc='widget.format_currency_no_symbol(line.price_display_one)' />
+                                    </div>
+                                </td>
+                                <td  class="pos-receipt-left-align" style="padding-right: 4.5em;"><t t-esc="widget.format_currency_no_symbol(line.tax)"/></td>
+                                <td class="pos-receipt-left-align" style="width: 5%"><t t-esc='widget.format_currency_no_symbol(line.price_display)' class="price_display pos-receipt-right-align"/></td>
+                            </tr>
+                        </t>
+                    </tr>
+                    </table>
+                </t>
         </t>
-    </t>
 </templates>
+


### PR DESCRIPTION
Changed the way posticket xml is extended from odoo base pos.

The ticket adapts to the characteristics that a fiscal invoice must have according to the DGII, for refenrence visit the link down bellow:

[https://dgii.gov.do/cicloContribuyente/facturacion/comprobantesFiscales/Documents/Formato-de-factura-para-Soluciones-Fiscales.pdf?csf=1&e=5f3ZCH](DGII reports fiscal invoices)

before:
![antes](https://user-images.githubusercontent.com/49220228/199585840-f99771e1-0bc6-4083-8dc9-5477d2fccf67.png)

After:
![image](https://user-images.githubusercontent.com/49220228/199762425-80065b53-34c8-4837-be3c-7996cfb5f4f7.png)




instead of "replace"  we extend it with "after" and "inner"  for a better, maintainable and clean code. 

Now the header and footer play a roll when the user wants to display his store location in the pos ticket.