### PR TITLE
[13.0][FIX] l10n_do_accounting: analytic account removed when inv canceled

### DIFF
--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -321,6 +321,9 @@ class AccountMove(models.Model):
             action["context"] = {"default_move_id": fiscal_invoice.id}
             return action
 
+        for move in self:
+            move.mapped('line_ids.analytic_line_ids').unlink()
+
         return super(AccountMove, self).button_cancel()
 
     def action_reverse(self):


### PR DESCRIPTION
Now when on click button_cancel() the analytic accounts are affected and removed