### PR TITLE
[13.0][FIX] l10n_do_accounting: analytic accounts removed when invoice canceled

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "13.0.1.9.18",
+    "version": "13.0.1.10.0",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/wizard/account_move_cancel.py
+++ b/l10n_do_accounting/wizard/account_move_cancel.py
@@ -42,6 +42,7 @@ class AccountMoveCancel(models.TransientModel):
 
             # we call button_cancel() so dependency chain is
             # not broken in other modules extending that function
+            invoice.mapped('line_ids.analytic_line_ids').unlink()
             invoice.with_context(skip_cancel_wizard=True).button_cancel()
             invoice.l10n_do_cancellation_type = self.l10n_do_cancellation_type
 


### PR DESCRIPTION
Now when invoice canceled, the analytic account is removed(keeping the odoo flow of "cancel")