### PR TITLE
[FIX] [15.0] l10n_do_accounting: Fixing access permissions error when canceling fiscal invoices

### DIFF
--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -431,7 +431,7 @@ class AccountMove(models.Model):
         if fiscal_invoice and not self.env.context.get("skip_cancel_wizard", False):
             action = self.env.ref(
                 "l10n_do_accounting.action_account_move_cancel"
-            ).read()[0]
+            ).sudo().read()[0]
             action["context"] = {"default_move_id": fiscal_invoice.id}
             return action
 


### PR DESCRIPTION
This patch fixes issue #1040 