### PR TITLE
[14.0][FIX] l10n_do_accounting: wizard fix to create a credit note

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "14.0.2.18.1",
+    "version": "14.0.2.18.2",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -640,7 +640,7 @@ class AccountMove(models.Model):
             return res
 
         if self.country_code == "DO":
-            res["l10n_do_origin_ncf"] = self.l10n_latam_document_number
+            res["l10n_do_origin_ncf"] = self.ref
             res["l10n_do_ecf_modification_code"] = l10n_do_ecf_modification_code
 
         if refund_type in ("percentage", "fixed_amount"):

--- a/l10n_do_accounting/wizard/account_move_reversal.py
+++ b/l10n_do_accounting/wizard/account_move_reversal.py
@@ -155,7 +155,8 @@ class AccountMoveReversal(models.TransientModel):
                 if move_ids_use_document:
                     raise UserError(
                         _(
-                            "You can only reverse documents with legal invoicing documents from Latin America one at a time.\nProblematic documents: %s"
+                            "You can only reverse documents with legal invoicing documents from Latin America "
+                            "one at a time.\nProblematic documents: %s"
                         )
                         % ", ".join(move_ids_use_document.mapped("name"))
                     )

--- a/l10n_do_accounting/wizard/account_move_reversal.py
+++ b/l10n_do_accounting/wizard/account_move_reversal.py
@@ -181,17 +181,20 @@ class AccountMoveReversal(models.TransientModel):
                 )
         super(AccountMoveReversal, self - do_wizard)._compute_document_type()
 
-    @api.depends('l10n_latam_document_type_id')
+    @api.depends("l10n_latam_document_type_id")
     def _compute_l10n_latam_manual_document_number(self):
         self.l10n_latam_manual_document_number = False
         do_wizard = self.filtered(
             lambda w: w.journal_id
-                      and w.journal_id.l10n_latam_use_documents
-                        and w.country_code == "DO"
-                    and w.move_ids
-            )
+            and w.journal_id.l10n_latam_use_documents
+            and w.country_code == "DO"
+            and w.move_ids
+        )
         for rec in do_wizard:
             if rec.journal_id and rec.journal_id.l10n_latam_use_documents:
-                rec.l10n_latam_manual_document_number = self.env['account.move']._is_manual_document_number(
-                    rec.journal_id)
-        super(AccountMoveReversal, self - do_wizard)._compute_l10n_latam_manual_document_number()
+                rec.l10n_latam_manual_document_number = self.env[
+                    "account.move"
+                ]._is_manual_document_number(rec.journal_id)
+        super(
+            AccountMoveReversal, self - do_wizard
+        )._compute_l10n_latam_manual_document_number()

--- a/l10n_do_accounting/wizard/account_move_reversal.py
+++ b/l10n_do_accounting/wizard/account_move_reversal.py
@@ -136,3 +136,62 @@ class AccountMoveReversal(models.TransientModel):
                 l10n_do_ecf_modification_code=self.l10n_do_ecf_modification_code,
             ),
         ).reverse_moves()
+
+    @api.depends("move_ids", "journal_id")
+    def _compute_document_type(self):
+        self.l10n_latam_available_document_type_ids = False
+        self.l10n_latam_document_type_id = False
+        self.l10n_latam_use_documents = False
+        do_wizard = self.filtered(
+            lambda w: w.journal_id
+            and w.journal_id.l10n_latam_use_documents
+            and w.country_code == "DO"
+        )
+        for record in do_wizard:
+            if len(record.move_ids) > 1:
+                move_ids_use_document = record.move_ids._origin.filtered(
+                    lambda move: move.l10n_latam_use_documents
+                )
+                if move_ids_use_document:
+                    raise UserError(
+                        _(
+                            "You can only reverse documents with legal invoicing documents from Latin America one at a time.\nProblematic documents: %s"
+                        )
+                        % ", ".join(move_ids_use_document.mapped("name"))
+                    )
+            else:
+                record.l10n_latam_use_documents = (
+                    record.journal_id.l10n_latam_use_documents
+                )
+
+            if record.l10n_latam_use_documents:
+                refund = record.env["account.move"].new(
+                    {
+                        "move_type": record._reverse_type_map(
+                            record.move_ids.move_type
+                        ),
+                        "journal_id": record.journal_id.id,
+                        "partner_id": record.move_ids.partner_id.id,
+                        "company_id": record.move_ids.company_id.id,
+                    }
+                )
+                record.l10n_latam_document_type_id = refund.l10n_latam_document_type_id
+                record.l10n_latam_available_document_type_ids = (
+                    refund.l10n_latam_available_document_type_ids
+                )
+        super(AccountMoveReversal, self - do_wizard)._compute_document_type()
+
+    @api.depends('l10n_latam_document_type_id')
+    def _compute_l10n_latam_manual_document_number(self):
+        self.l10n_latam_manual_document_number = False
+        do_wizard = self.filtered(
+            lambda w: w.journal_id
+                      and w.journal_id.l10n_latam_use_documents
+                        and w.country_code == "DO"
+                    and w.move_ids
+            )
+        for rec in do_wizard:
+            if rec.journal_id and rec.journal_id.l10n_latam_use_documents:
+                rec.l10n_latam_manual_document_number = self.env['account.move']._is_manual_document_number(
+                    rec.journal_id)
+        super(AccountMoveReversal, self - do_wizard)._compute_l10n_latam_manual_document_number()


### PR DESCRIPTION
Overwritten functions in which it is possible to add document type and document number to non-fiscal invoice credit notes.