### PR TITLE
[14.0][IMP] l10n_do_accounting: allow to set fiscal number when new ncf expiration date

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "14.0.2.18.2",
+    "version": "14.0.2.19.0",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/i18n/es_DO.po
+++ b/l10n_do_accounting/i18n/es_DO.po
@@ -6,16 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-18 15:55+0000\n"
-"PO-Revision-Date: 2023-09-18 11:56-0400\n"
+"POT-Creation-Date: 2024-02-06 14:49+0000\n"
+"PO-Revision-Date: 2024-02-06 10:53-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: es\n"
+"Language: es_DO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: l10n_do_accounting
 #: code:addons/l10n_do_accounting/models/account_move.py:0
@@ -447,11 +447,21 @@ msgid "Companies"
 msgstr "Compañías"
 
 #. module: l10n_do_accounting
+#: model:ir.model.fields,field_description:l10n_do_accounting.field_l10n_do_account_journal_document_type__company_id
+msgid "Company"
+msgstr "Compañía"
+
+#. module: l10n_do_accounting
 #: model:ir.model.fields,field_description:l10n_do_accounting.field_account_bank_statement_line__l10n_do_company_in_contingency
 #: model:ir.model.fields,field_description:l10n_do_accounting.field_account_move__l10n_do_company_in_contingency
 #: model:ir.model.fields,field_description:l10n_do_accounting.field_account_payment__l10n_do_company_in_contingency
 msgid "Company in contingency"
 msgstr "Compañía en contingencia"
+
+#. module: l10n_do_accounting
+#: model:ir.model.fields,help:l10n_do_accounting.field_l10n_do_account_journal_document_type__company_id
+msgid "Company related to this journal"
+msgstr "Empresa relacionada con este diario"
 
 #. module: l10n_do_accounting
 #: model:ir.model,name:l10n_do_accounting.model_res_partner
@@ -944,6 +954,15 @@ msgstr ""
 #. module: l10n_do_accounting
 #: model_terms:ir.ui.view,arch_db:l10n_do_accounting.view_move_form
 msgid ""
+"Notice. Document Number field enabled because a new Fiscal Number Expiration date was "
+"set on journal"
+msgstr ""
+"Aviso. Se ha activado el campo Número de Comprobante porque se ha establecido una nueva "
+"fecha de expiración del NCF en el diario"
+
+#. module: l10n_do_accounting
+#: model_terms:ir.ui.view,arch_db:l10n_do_accounting.view_move_form
+msgid ""
 "Notice. This company is in a transient state of contingency for Electronic Invoice "
 "issuing. NCF issuing has been enabled."
 msgstr ""
@@ -965,8 +984,8 @@ msgstr "Reembolso Parcial"
 #. module: l10n_do_accounting
 #: code:addons/l10n_do_accounting/models/account_journal.py:0
 #, python-format
-msgid "Partner %s is needed to issue a fiscal invoice"
-msgstr "El %s del contacto es necesario para emitir una factura fiscal"
+msgid "Partner (%s) %s is needed to issue a fiscal invoice"
+msgstr "El contacto (%s) requiere un %s para emitir una factura fiscal"
 
 #. module: l10n_do_accounting
 #: model:ir.model.fields,field_description:l10n_do_accounting.field_account_journal__l10n_do_payment_form
@@ -1034,6 +1053,13 @@ msgstr ""
 "Las facturas seleccionadas no pueden cancelarse ya que se encuentran en estado Pagadas."
 
 #. module: l10n_do_accounting
+#: model:ir.model.fields,field_description:l10n_do_accounting.field_account_bank_statement_line__l10n_do_show_expiration_date_msg
+#: model:ir.model.fields,field_description:l10n_do_accounting.field_account_move__l10n_do_show_expiration_date_msg
+#: model:ir.model.fields,field_description:l10n_do_accounting.field_account_payment__l10n_do_show_expiration_date_msg
+msgid "Show Expiration Date Message"
+msgstr "Mostrar Mensaje Fecha Expiración"
+
+#. module: l10n_do_accounting
 #: model:ir.model.fields,help:l10n_do_accounting.field_account_bank_statement_line__l10n_do_fiscal_number
 #: model:ir.model.fields,help:l10n_do_accounting.field_account_move__l10n_do_fiscal_number
 #: model:ir.model.fields,help:l10n_do_accounting.field_account_payment__l10n_do_fiscal_number
@@ -1079,6 +1105,18 @@ msgstr ""
 "colocar manualmente."
 
 #. module: l10n_do_accounting
+#: model:ir.model.fields,help:l10n_do_accounting.field_account_bank_statement_line__l10n_do_show_expiration_date_msg
+#: model:ir.model.fields,help:l10n_do_accounting.field_account_move__l10n_do_show_expiration_date_msg
+#: model:ir.model.fields,help:l10n_do_accounting.field_account_payment__l10n_do_show_expiration_date_msg
+msgid ""
+"Technical field to hide/show message on invoice header that indicate fiscal number must "
+"be input manually because a new expiration date was set on journal"
+msgstr ""
+"Campo técnico para ocultar/mostrar un mensaje en el encabezado de las facturas para "
+"indicar que el NCF debe ser digital manualmente porque se colocó una nueva fecha de "
+"expiración en el diario"
+
+#. module: l10n_do_accounting
 #: model:ir.model.fields,help:l10n_do_accounting.field_account_debit_note__l10n_latam_country_code
 #: model:ir.model.fields,help:l10n_do_accounting.field_account_move_reversal__country_code
 msgid "Technical field used to hide/show fields regarding the localization"
@@ -1094,12 +1132,6 @@ msgstr "Ya existe una factura de ventas con el NCF %s"
 #: model:ir.model.fields,field_description:l10n_do_accounting.field_account_debit_note__l10n_latam_use_documents
 msgid "Use Documents"
 msgstr "Es fiscal"
-
-#. module: l10n_do_accounting
-#: code:addons/l10n_do_accounting/models/account_move.py:0
-#, python-format
-msgid "There is already a sale invoice with fiscal number %s"
-msgstr "Ya existe una factura de ventas con el NCF %s"
 
 #. module: l10n_do_accounting
 #: model_terms:ir.ui.view,arch_db:l10n_do_accounting.view_account_move_reversal_inherited
@@ -1184,6 +1216,17 @@ msgid "You are not allowed to modify %s after partner fiscal document issuing"
 msgstr ""
 "No tiene permiso de modificar los campos %s luego de la emisión de un documento fiscal "
 "de este contacto"
+
+#. module: l10n_do_accounting
+#: code:addons/l10n_do_accounting/wizard/account_move_reversal.py:0
+#, python-format
+msgid ""
+"You can only reverse documents with legal invoicing documents from Latin America one at "
+"a time.\n"
+"Problematic documents: %s"
+msgstr ""
+"Solo puede aplicar Notas de Crédito a una factura a la vez.\n"
+"Documentos señalados: %s"
 
 #. module: l10n_do_accounting
 #: code:addons/l10n_do_accounting/models/account_move.py:0

--- a/l10n_do_accounting/models/account_move.py
+++ b/l10n_do_accounting/models/account_move.py
@@ -118,6 +118,12 @@ class AccountMove(models.Model):
         "ECF XML File Name", copy=False, readonly=True
     )
     l10n_latam_manual_document_number = fields.Boolean(store=True)
+    l10n_do_show_expiration_date_msg = fields.Boolean(
+        "Show Expiration Date Message",
+        compute="_compute_l10n_do_show_expiration_date_msg",
+        help="Technical field to hide/show message on invoice header that indicate fiscal number must be input "
+        "manually because a new expiration date was set on journal",
+    )
 
     def init(self):
         super(AccountMove, self).init()
@@ -166,6 +172,43 @@ class AccountMove(models.Model):
             expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid
         )
 
+    def _l10n_do_is_new_expiration_date(self):
+        self.ensure_one()
+        last_invoice = self.search(
+            [
+                ("company_id", "=", self.company_id.id),
+                ("move_type", "=", self.move_type),
+                (
+                    "l10n_latam_document_type_id",
+                    "=",
+                    self.l10n_latam_document_type_id.id,
+                ),
+                ("posted_before", "=", True),
+                ("id", "!=", self.id or self._origin.id),
+            ],
+            order="invoice_date, id desc",
+            limit=1,
+        )
+        if not last_invoice:
+            return False
+
+        return (
+            last_invoice.l10n_do_ncf_expiration_date < self.l10n_do_ncf_expiration_date
+        )
+
+    @api.depends("l10n_do_ncf_expiration_date", "journal_id")
+    def _compute_l10n_do_show_expiration_date_msg(self):
+        l10n_do_internal_invoices = self.filtered(
+            lambda inv: inv.l10n_latam_use_documents
+            and inv.l10n_latam_document_type_id
+            and inv.country_code == "DO"
+            and not inv.l10n_latam_manual_document_number
+        )
+        for invoice in l10n_do_internal_invoices:
+            invoice.l10n_do_show_expiration_date_msg = invoice._l10n_do_is_new_expiration_date()
+
+        (self - l10n_do_internal_invoices).l10n_do_show_expiration_date_msg = False
+
     @api.depends(
         "journal_id.l10n_latam_use_documents",
         "l10n_latam_manual_document_number",
@@ -198,7 +241,7 @@ class AccountMove(models.Model):
                         ("id", "!=", invoice.id or invoice._origin.id),
                     ],
                 )
-            )
+            ) or invoice.l10n_do_show_expiration_date_msg
 
         (self - l10n_do_internal_invoices).l10n_do_enable_first_sequence = False
 
@@ -668,6 +711,13 @@ class AccountMove(models.Model):
                 move._is_l10n_do_manual_document_number()
             )
 
+            move.l10n_do_ncf_expiration_date = (
+                move.journal_id.l10n_do_document_type_ids.filtered(
+                    lambda doc: doc.l10n_latam_document_type_id
+                    == move.l10n_latam_document_type_id
+                ).l10n_do_ncf_expiration_date
+            )
+
         super(
             AccountMove, self - l10n_do_recs_with_journal_id
         )._compute_l10n_latam_manual_document_number()
@@ -763,13 +813,6 @@ class AccountMove(models.Model):
         ):
             if not invoice.amount_total:
                 raise UserError(_("Fiscal invoice cannot be posted with amount zero."))
-
-            invoice.l10n_do_ncf_expiration_date = (
-                invoice.journal_id.l10n_do_document_type_ids.filtered(
-                    lambda doc: doc.l10n_latam_document_type_id
-                    == invoice.l10n_latam_document_type_id
-                ).l10n_do_ncf_expiration_date
-            )
 
         non_payer_type_invoices = l10n_do_invoices.filtered(
             lambda inv: not inv.partner_id.l10n_do_dgii_tax_payer_type

--- a/l10n_do_accounting/views/account_move_views.xml
+++ b/l10n_do_accounting/views/account_move_views.xml
@@ -9,6 +9,7 @@
                 <field name="is_ecf_invoice" invisible="1"/>
                 <field name="l10n_do_company_in_contingency" invisible="1"/>
                 <field name="l10n_do_enable_first_sequence" invisible="1" force_save="1"/>
+                <field name="l10n_do_show_expiration_date_msg" invisible="1"/>
             </field>
             <xpath expr="//field[@name='tax_lock_date_message']/.." position="after">
                 <div class="alert alert-warning"
@@ -19,6 +20,15 @@
                      ('l10n_do_company_in_contingency', '=', False),
                      ('state', '!=', 'draft')]}">
                     Notice. This company is in a transient state of contingency for Electronic Invoice issuing. NCF issuing has been enabled.
+                </div>
+                <div class="alert alert-warning"
+                     role="alert" style="margin-bottom:0px;"
+                     attrs="{'invisible': ['|', '|', '|',
+                     ('move_type', '=', 'entry'),
+                     ('country_code', '!=', 'DO'),
+                     ('l10n_do_show_expiration_date_msg', '=', False),
+                     ('state', '!=', 'draft')]}">
+                    Notice. Document Number field enabled because a new Fiscal Number Expiration date was set on journal
                 </div>
             </xpath>
             <xpath expr="//button[@name='button_cancel']" position="attributes">


### PR DESCRIPTION
En la versión 13.0 y anteriores, los rangos de secuencia fiscales podían ser gestionados desde las secuencias internas (ir.sequence) de manera nativa. A partir de la versión 14 esto ya no es posible. Más info [aquí](https://github.com/indexa-git/l10n-dominicana/tree/14.0/l10n_do_accounting#diarios).

Cuando se produce un cambio de año y se llega a la fecha de vencimiento de un conjunto de números de comprobante fiscal autorizados por la DGII, puede surgir la necesidad de descartar una parte de ese conjunto y comenzar a utilizar una numeración completamente nueva para la facturación.

Este PR propuesto permite la posibilidad de ingresar manualmente el número del comprobante fiscal cuando se detecta una nueva fecha de vencimiento para los comprobantes.

Video demostración: https://app.screencastify.com/v3/watch/fXseuApFpjWoIHg7hPxg

Gracias @jose250698 por reportar el issue.