### PR TITLE
[FIX] l10n_do_accounting: couldn't compute isdigit when creating new contacts (both name and vat where false)

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "countries": ["do"],
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],

--- a/l10n_do_accounting/models/res_partner.py
+++ b/l10n_do_accounting/models/res_partner.py
@@ -101,7 +101,7 @@ class Partner(models.Model):
     def _compute_l10n_do_dgii_payer_type(self):
         """Compute the type of partner depending on soft decisions"""
         for partner in self:
-            vat = partner.vat or partner.name
+            vat = partner.vat or partner.name or ''
             vat_len = len(vat) if vat else 0
             upper_name = partner.name.upper() if partner.name else ""
             is_dominican_partner = partner.country_code == "DO"


### PR DESCRIPTION
**Couldn't create Partner from Partners->Create**

Impacted versions:

 - 17.0-mig-001-jl

Steps to reproduce:

 1. Go to Contacts
 2. Click "Create"

Current behavior:

 - Since both name and vat are False at the time of creation, calling isdigit() on vat (boolean False) threw an Exception.