### PR TITLE
Update actions/upload-artifact to v3 in GitHub workflows

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,7 +83,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zip && zip -r modules.zip .
 
       - name: Upload repository results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: modules
           path: modules.zip


### PR DESCRIPTION
Update actions/upload-artifact from v2 to v3 in .github/workflows/tests.yaml to avoid errors due to discontinuation of previous versions.