### PR TITLE
[FIX] Sum other taxes to invoice total

### DIFF
--- a/l10n_do_accounting/__manifest__.py
+++ b/l10n_do_accounting/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "license": "LGPL-3",
     "website": "https://github.com/odoo-dominicana",
-    "version": "16.0.1.5.9",
+    "version": "16.0.1.5.10",
     # any module necessary for this one to work correctly
     "depends": ["l10n_latam_invoice_document", "l10n_do"],
     # always loaded

--- a/l10n_do_accounting/models/account_move_line.py
+++ b/l10n_do_accounting/models/account_move_line.py
@@ -54,6 +54,13 @@ class AccountMoveLine(models.Model):
         taxed_lines = invoice_line_ids.filtered(
             lambda x: x.tax_ids and any(tax for tax in x.tax_ids if tax.amount)
         )
+        other_taxes_lines = self.filtered(
+            lambda x: x.tax_line_id and x.tax_line_id.tax_group_id not in [group_itbis, group_isr]
+        )
+        other_taxes_amount = sum(
+            abs(self.currency_id.round(line.amount_currency)) for line in other_taxes_lines
+        )
+
         exempt_lines = invoice_line_ids.filtered(
             lambda x: not x.tax_ids or any(tax for tax in x.tax_ids if not tax.amount)
         )
@@ -135,6 +142,7 @@ class AccountMoveLine(models.Model):
             + result["itbis_18_tax_amount"]
             + result["itbis_16_tax_amount"]
             + result["itbis_0_tax_amount"]
+            + other_taxes_amount
         )
 
         if self.currency_id != self.company_id.currency_id:


### PR DESCRIPTION
If a sales invoice has the 18% ITBIS and the 10% legal tip taxes, the printed invoice only reflects the ITBIS.

Ex:
Subtotal 1,000
ITBIS 180
Legal tip 100
Total 1,280

But in the printed invoice the total is 1,180